### PR TITLE
Replace timer that checks the active window with the windows event system

### DIFF
--- a/OverlayPlugin.Core/NativeMethods.cs
+++ b/OverlayPlugin.Core/NativeMethods.cs
@@ -12,6 +12,33 @@ namespace RainbowMage.OverlayPlugin
     /// </summary>
     static class NativeMethods
     {
+
+        static WinEventDelegate dele = null;
+
+        static NativeMethods()
+        {
+            dele = new WinEventDelegate(WinEventProc);
+            ActiveWindowHandle = GetForegroundWindow();
+            IntPtr m_hhook = SetWinEventHook(EVENT_SYSTEM_FOREGROUND, EVENT_SYSTEM_FOREGROUND, IntPtr.Zero, dele, 0, 0, WINEVENT_OUTOFCONTEXT);
+        }
+
+        delegate void WinEventDelegate(IntPtr hWinEventHook, uint eventType, IntPtr hwnd, int idObject, int idChild, uint dwEventThread, uint dwmsEventTime);
+
+        [DllImport("user32.dll")]
+        static extern IntPtr SetWinEventHook(uint eventMin, uint eventMax, IntPtr hmodWinEventProc, WinEventDelegate lpfnWinEventProc, uint idProcess, uint idThread, uint dwFlags);
+
+        private const uint WINEVENT_OUTOFCONTEXT = 0;
+        private const uint EVENT_SYSTEM_FOREGROUND = 3;
+
+        public static event EventHandler<IntPtr> ActiveWindowChanged;
+        public static IntPtr ActiveWindowHandle;
+        private static void WinEventProc(IntPtr hWinEventHook, uint eventType, IntPtr hwnd, int idObject, int idChild, uint dwEventThread, uint dwmsEventTime)
+        {
+            ActiveWindowHandle = hwnd;
+            ActiveWindowChanged?.Invoke(null, hwnd);
+        }
+
+
         public struct BlendFunction
         {
             public byte BlendOp;

--- a/OverlayPlugin.Core/PluginMain.cs
+++ b/OverlayPlugin.Core/PluginMain.cs
@@ -199,9 +199,7 @@ namespace RainbowMage.OverlayPlugin
                 }
             }
 
-            xivWindowTimer = new System.Timers.Timer();
-            xivWindowTimer.Interval = 1000;
-            xivWindowTimer.Elapsed += (o, e) =>
+            NativeMethods.ActiveWindowChanged += (sender, hWndFg) =>
             {
                 if (Config.HideOverlaysWhenNotActive)
                 {
@@ -212,16 +210,19 @@ namespace RainbowMage.OverlayPlugin
                         try
                         {
                             uint pid;
-                            var hWndFg = NativeMethods.GetForegroundWindow();
                             if (hWndFg == IntPtr.Zero)
                             {
                                 return;
                             }
                             NativeMethods.GetWindowThreadProcessId(hWndFg, out pid);
-                            var exePath = Process.GetProcessById((int)pid).MainModule.FileName;
 
-                            if (Path.GetFileName(exePath.ToString()) == "ffxiv.exe" ||
-                                Path.GetFileName(exePath.ToString()) == "ffxiv_dx11.exe" ||
+                            if (pid == 0)
+                                return;
+
+                            var exePath = Process.GetProcessById((int)pid).MainModule.FileName;
+                            var fileName = Path.GetFileName(exePath.ToString());
+                            if (fileName == "ffxiv.exe" ||
+                                fileName == "ffxiv_dx11.exe" ||
                                 exePath.ToString() == Process.GetCurrentProcess().MainModule.FileName)
                             {
                                 shouldBeVisible = true;


### PR DESCRIPTION
This allows for the plugin to appear and disappear as soon as the active window is changed and reduces the cpu usage of the plugin


ported over to this branch as per 

https://github.com/hibiyasleep/OverlayPlugin/pull/42#issuecomment-530247735