### PR TITLE
Monitor the event that gets fired when a window is restored from being minimized as well

### DIFF
--- a/OverlayPlugin.Core/NativeMethods.cs
+++ b/OverlayPlugin.Core/NativeMethods.cs
@@ -19,7 +19,8 @@ namespace RainbowMage.OverlayPlugin
         {
             dele = new WinEventDelegate(WinEventProc);
             ActiveWindowHandle = GetForegroundWindow();
-            IntPtr m_hhook = SetWinEventHook(EVENT_SYSTEM_FOREGROUND, EVENT_SYSTEM_FOREGROUND, IntPtr.Zero, dele, 0, 0, WINEVENT_OUTOFCONTEXT);
+            SetWinEventHook(EVENT_SYSTEM_FOREGROUND, EVENT_SYSTEM_FOREGROUND, IntPtr.Zero, dele, 0, 0, WINEVENT_OUTOFCONTEXT);
+            SetWinEventHook(EVENT_SYSTEM_MINIMIZEEND, EVENT_SYSTEM_MINIMIZEEND, IntPtr.Zero, dele, 0, 0, WINEVENT_OUTOFCONTEXT);
         }
 
         delegate void WinEventDelegate(IntPtr hWinEventHook, uint eventType, IntPtr hwnd, int idObject, int idChild, uint dwEventThread, uint dwmsEventTime);
@@ -29,6 +30,7 @@ namespace RainbowMage.OverlayPlugin
 
         private const uint WINEVENT_OUTOFCONTEXT = 0;
         private const uint EVENT_SYSTEM_FOREGROUND = 3;
+        private const uint EVENT_SYSTEM_MINIMIZEEND = 0x0017;
 
         public static event EventHandler<IntPtr> ActiveWindowChanged;
         public static IntPtr ActiveWindowHandle;


### PR DESCRIPTION
Windows that were minimized could be restored and the overlay would still be displayed