### PR TITLE
Add HasSubscriber helper function

### DIFF
--- a/OverlayPlugin.Core/EventDispatcher.cs
+++ b/OverlayPlugin.Core/EventDispatcher.cs
@@ -72,6 +72,18 @@ namespace RainbowMage.OverlayPlugin
             }
         }
 
+        // Can be used to check that an event will be delivered before building
+        // an expensive JObject that would otherwise be thrown away.
+        public static bool HasSubscriber(string eventName)
+        {
+            if (!eventFilter.ContainsKey(eventName))
+                return false;
+            lock (eventFilter[eventName])
+            {
+                return eventFilter[eventName].Count > 0;
+            }
+        }
+
         public static void DispatchEvent(JObject e)
         {
             var eventType = e["type"].ToString();

--- a/OverlayPlugin.Core/EventSourceBase.cs
+++ b/OverlayPlugin.Core/EventSourceBase.cs
@@ -74,5 +74,10 @@ namespace RainbowMage.OverlayPlugin
         {
             EventDispatcher.DispatchEvent(e);
         }
+
+        protected bool HasSubscriber(string eventName)
+        {
+            return EventDispatcher.HasSubscriber(eventName);
+        }
     }
 }


### PR DESCRIPTION
In preparation for adding enmity (and avoiding options about whether to send data), let the plugin automatically avoid expensive object construction if nobody is asking for it.