### PR TITLE
Add PartyChanged event

### DIFF
--- a/OverlayPlugin.Core/EventSources/MiniParseEventSource.cs
+++ b/OverlayPlugin.Core/EventSources/MiniParseEventSource.cs
@@ -72,7 +72,7 @@ namespace RainbowMage.OverlayPlugin.EventSources
                 DispatchEvent(obj);
             };
 
-            FFXIVRepository.RegisterPartyChangeDelegate(PartyChangeHandler);
+            FFXIVRepository.RegisterPartyChangeDelegate((partyList, partySize) => DispatchPartyChangeEvent());
         }
 
         private void LogLineHandler(bool isImport, LogLineEventArgs args)
@@ -151,7 +151,7 @@ namespace RainbowMage.OverlayPlugin.EventSources
             public bool inParty;
         }
 
-        private void PartyChangeHandler(ReadOnlyCollection<uint> unusedPartyList = null, int unusedPartySize = 0)
+        private void DispatchPartyChangeEvent()
         {
             var combatants = FFXIVRepository.GetCombatants();
             if (combatants == null)
@@ -159,11 +159,8 @@ namespace RainbowMage.OverlayPlugin.EventSources
 
             List<PartyMember> result = new List<PartyMember>(24);
 
-            // Because we have to look through the entire combatants array
-            // to do the id => instead, just look up anybody who is in the
-            // party or alliance rather than anything in partyList.
-            // The partyList contents are equivalent to the set of ids
-            // enumerated by |query|.
+            // The partyList contents from the PartyListChangedDelegate
+            // are equivalent to the set of ids enumerated by |query|
             var query = combatants.Where(c => c.PartyType != PartyTypeEnum.None);
             foreach (var c in query)
             {

--- a/OverlayPlugin.Core/FFXIVRepository.cs
+++ b/OverlayPlugin.Core/FFXIVRepository.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Collections.ObjectModel;
 using System.Linq;
 using Advanced_Combat_Tracker;
 using FFXIV_ACT_Plugin.Common;
@@ -118,6 +119,14 @@ namespace RainbowMage.OverlayPlugin
             return playerInfo.Name;
         }
 
+        public static ReadOnlyCollection<FFXIV_ACT_Plugin.Common.Models.Combatant> GetCombatants()
+        {
+            var repo = GetRepository();
+            if (repo == null) return null;
+
+            return repo.GetCombatantList();
+        }
+
         // LogLineDelegate(uint EventType, uint Seconds, string logline);
         public static void RegisterLogLineHandler(Action<uint, uint, string> handler)
         {
@@ -125,10 +134,24 @@ namespace RainbowMage.OverlayPlugin
             sub.LogLine += new LogLineDelegate(handler);
         }
 
+        // NetworkReceivedDelegate(string connection, long epoch, byte[] message)
         public static void RegisterNetworkParser(Action<string, long, byte[]> handler)
         {
             var sub = GetSubscription();
             sub.NetworkReceived += new NetworkReceivedDelegate(handler);
+        }
+
+        // PartyListChangedDelegate(ReadOnlyCollection<uint> partyList, int partySize)
+        //
+        // Details: partySize may differ from partyList.Count.
+        // In non-cross world parties, players who are not in the same
+        // zone count in the partySize but do not appear in the partyList.
+        // In cross world parties, nobody will appear in the partyList.
+        // Alliance data members show up in partyList but not in partySize.
+        public static void RegisterPartyChangeDelegate(Action<ReadOnlyCollection<uint>, int> handler)
+        {
+            var sub = GetSubscription();
+            sub.PartyListChanged += new PartyListChangedDelegate(handler);
         }
     }
 }


### PR DESCRIPTION
Adds a new event for party changed.  Because the partySize is probably confusing (see comments in the patch), it's not provided as part of the event.  Just getting the length of the party is good enough to know when you are in 8 or 24 person content.

This handler doesn't use any of the parameters given to it, so can also be called manually to send initial data.