### PR TITLE
fix miniparse and update ja-JP labels

### DIFF
--- a/OverlayPlugin.Core/Overlays/MiniParseConfigPanel.ja-JP.resx
+++ b/OverlayPlugin.Core/Overlays/MiniParseConfigPanel.ja-JP.resx
@@ -319,4 +319,19 @@
   <data name="label12.Text" xml:space="preserve">
     <value>オーバーレイが見つからない、リサイズが出来なくなった場合等に使用して下さい。</value>
   </data>
+  <data name="btnResetZoom.Text" xml:space="preserve">
+    <value>リセット</value>
+  </data>
+  <data name="checkLogConsoleMessages.Text" xml:space="preserve">
+    <value>オーバーレイのコンソールメッセージをログに表示する</value>
+  </data>
+  <data name="label15.Text" xml:space="preserve">
+    <value>ズーム</value>
+  </data>
+  <data name="checkNoFocus.Text" xml:space="preserve">
+    <value>このオーバーレイにはフォーカスしない</value>
+  </data>
+  <data name="lblNoFocus.Text" xml:space="preserve">
+    <value>フォーカスの無効</value>
+  </data>
 </root>

--- a/OverlayPlugin.Core/Overlays/MiniParseOverlayConfig.cs
+++ b/OverlayPlugin.Core/Overlays/MiniParseOverlayConfig.cs
@@ -43,7 +43,7 @@ namespace RainbowMage.OverlayPlugin.Overlays
             }
         }
 
-        private int zoom;
+        private int zoom = 1;
         public int Zoom
         {
             get
@@ -63,7 +63,7 @@ namespace RainbowMage.OverlayPlugin.Overlays
         public MiniParseOverlayConfig(string name) : base(name)
         {
             this.noFocus = true;
-            this.zoom = 0;
+            this.zoom = 1;
         }
 
         public MiniParseOverlayConfig() : base(null) { }

--- a/translations.json
+++ b/translations.json
@@ -319,7 +319,8 @@
     },
     "OverlayPlugin.Core/Overlays/MiniParseConfigPanel": {
         "btnResetZoom.Text": {
-            "en": "Reset"
+            "en": "Reset",
+            "ja-JP": "リセット"
         },
         "buttonMiniParseOpenDevTools.Text": {
             "en": "Open DevTools",
@@ -348,10 +349,12 @@
             "zh-CN": "此模板需要使用ACTWebSocket"
         },
         "checkLogConsoleMessages.Text": {
-            "en": "Show console messages from this overlay in the overlay log"
+            "en": "Show console messages from this overlay in the overlay log",
+            "ja-JP": "オーバーレイのコンソールメッセージをログに表示する"
         },
         "checkNoFocus.Text": {
-            "en": "Don't accept focus for this overlay"
+            "en": "Don't accept focus for this overlay",
+            "ja-JP": "このオーバーレイにはフォーカスしない"
         },
         "label1.Text": {
             "en": "URL",
@@ -374,7 +377,8 @@
             "zh-CN": "如果您找不到美化窗口或由于某种原因无法调整其大小时，请启用此选项。"
         },
         "label15.Text": {
-            "en": "Zoom"
+            "en": "Zoom",
+            "ja-JP": "ズーム"
         },
         "label2.Text": {
             "en": "Enable clickthru",
@@ -423,7 +427,8 @@
             "zh-CN": "锁定美化窗口"
         },
         "lblNoFocus.Text": {
-            "en": "No Focus"
+            "en": "No Focus",
+            "ja-JP": "フォーカスの無効"
         }
     },
     "OverlayPlugin.Core/Overlays/SpellTimerConfigPanel": {


### PR DESCRIPTION
- fix: The value `zoom` cannot set 0 because minimum value of slider is 1.
- update: Labels for Japanese.