### PR TITLE
Throw exceptions when a handler doesn't return an object

### DIFF
--- a/OverlayPlugin.Core/OverlayApi.cs
+++ b/OverlayPlugin.Core/OverlayApi.cs
@@ -102,6 +102,9 @@ namespace RainbowMage.OverlayPlugin
                     }
 
                     var result = EventDispatcher.CallHandler(message);
+                    if (result != null && result.Type != JTokenType.Object) {
+                        throw new Exception("Handler response must be an object or null");
+                    }
                     Renderer.ExecuteCallback(callback, result == null ? null : result.ToString(Newtonsoft.Json.Formatting.None));
                 }
                 catch (Exception e)

--- a/OverlayPlugin.Core/WSServer.cs
+++ b/OverlayPlugin.Core/WSServer.cs
@@ -252,6 +252,10 @@ namespace RainbowMage.OverlayPlugin
                     {
                         var response = EventDispatcher.CallHandler(data);
 
+                        if (response != null && response.Type != JTokenType.Object) {
+                            throw new Exception("Handler response must be an object or null");
+                        }
+
                         if (response == null) {
                             response = new JObject();
                             response["$isNull"] = true;


### PR DESCRIPTION
This only applies to WSServer, but enforce it for OverlayAPI
for consistency.

See also: https://github.com/quisquous/cactbot/issues/776