### PR TITLE
Fixed to return empty array if 'mychar' is null.

### DIFF
--- a/OverlayPlugin.Core/EventSources/EnmityMemory.cs
+++ b/OverlayPlugin.Core/EventSources/EnmityMemory.cs
@@ -272,6 +272,9 @@ namespace RainbowMage.OverlayPlugin.EventSources
             var seen = new HashSet<uint>();
             var mychar = GetSelfCombatant();
 
+            if (mychar == null) 
+                return result;
+
             int sz = 8;
             byte[] source = memory.GetByteArray(charmapAddress, sz * numMemoryCombatants);
             if (source == null || source.Length == 0)


### PR DESCRIPTION
Throw NRE at UpdateEnmity between logged-out and logging-in.
Fixed to return empty array if 'mychar' is null.
