### PR TITLE
Update ja-jp translations

### DIFF
--- a/OverlayPlugin.Core/Overlays/MiniParseConfigPanel.ja-JP.resx
+++ b/OverlayPlugin.Core/Overlays/MiniParseConfigPanel.ja-JP.resx
@@ -117,180 +117,26 @@
   <resheader name="writer">
     <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
-  <assembly alias="System.Drawing" name="System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a" />
-  <data name="label6.Location" type="System.Drawing.Point, System.Drawing">
-    <value>3, 144</value>
-  </data>
-  <data name="label6.Size" type="System.Drawing.Size, System.Drawing">
-    <value>149, 24</value>
-  </data>
   <data name="label6.Text" xml:space="preserve">
     <value>最大フレームレート</value>
-  </data>
-  <data name="label5.Location" type="System.Drawing.Point, System.Drawing">
-    <value>3, 120</value>
-  </data>
-  <data name="label5.Size" type="System.Drawing.Size, System.Drawing">
-    <value>149, 24</value>
-  </data>
-  <data name="textMiniParseSortKey.Location" type="System.Drawing.Point, System.Drawing">
-    <value>156, 97</value>
-  </data>
-  <data name="textMiniParseSortKey.Size" type="System.Drawing.Size, System.Drawing">
-    <value>447, 20</value>
-  </data>
-  <data name="label4.Location" type="System.Drawing.Point, System.Drawing">
-    <value>3, 96</value>
-  </data>
-  <data name="label4.Size" type="System.Drawing.Size, System.Drawing">
-    <value>149, 24</value>
-  </data>
-  <data name="label2.Location" type="System.Drawing.Point, System.Drawing">
-    <value>3, 24</value>
-  </data>
-  <data name="label2.Size" type="System.Drawing.Size, System.Drawing">
-    <value>149, 24</value>
   </data>
   <data name="label2.Text" xml:space="preserve">
     <value>クリックを透過させる</value>
   </data>
-  <data name="label3.Size" type="System.Drawing.Size, System.Drawing">
-    <value>149, 24</value>
-  </data>
   <data name="label3.Text" xml:space="preserve">
     <value>オーバーレイを表示する</value>
-  </data>
-  <data name="label1.Location" type="System.Drawing.Point, System.Drawing">
-    <value>3, 72</value>
-  </data>
-  <data name="label1.Size" type="System.Drawing.Size, System.Drawing">
-    <value>149, 24</value>
   </data>
   <data name="label1.Text" xml:space="preserve">
     <value>表示するURL</value>
   </data>
-  <data name="checkMiniParseVisible.Size" type="System.Drawing.Size, System.Drawing">
-    <value>443, 18</value>
-  </data>
-  <data name="checkMiniParseClickthru.Location" type="System.Drawing.Point, System.Drawing">
-    <value>158, 27</value>
-  </data>
-  <data name="checkMiniParseClickthru.Size" type="System.Drawing.Size, System.Drawing">
-    <value>443, 18</value>
-  </data>
-  <data name="buttonMiniParseCopyActXiv.Size" type="System.Drawing.Size, System.Drawing">
-    <value>193, 50</value>
-  </data>
-  <data name="buttonMiniParseOpenDevTools.Size" type="System.Drawing.Size, System.Drawing">
-    <value>193, 50</value>
-  </data>
   <data name="buttonMiniParseOpenDevTools.Text" xml:space="preserve">
     <value>DevToolsを開く</value>
-  </data>
-  <data name="buttonMiniParseReloadBrowser.Size" type="System.Drawing.Size, System.Drawing">
-    <value>194, 50</value>
   </data>
   <data name="buttonMiniParseReloadBrowser.Text" xml:space="preserve">
     <value>オーバーレイの表示をリロード</value>
   </data>
-  <data name="tableLayoutPanel3.Size" type="System.Drawing.Size, System.Drawing">
-    <value>598, 56</value>
-  </data>
-  <data name="panel1.Location" type="System.Drawing.Point, System.Drawing">
-    <value>3, 329</value>
-  </data>
-  <data name="panel1.Size" type="System.Drawing.Size, System.Drawing">
-    <value>598, 56</value>
-  </data>
-  <data name="textMiniParseUrl.Size" type="System.Drawing.Size, System.Drawing">
-    <value>410, 20</value>
-  </data>
-  <data name="buttonMiniParseSelectFile.Size" type="System.Drawing.Size, System.Drawing">
-    <value>37, 21</value>
-  </data>
-  <data name="tableLayoutPanel2.Location" type="System.Drawing.Point, System.Drawing">
-    <value>156, 73</value>
-  </data>
-  <data name="tableLayoutPanel2.Size" type="System.Drawing.Size, System.Drawing">
-    <value>447, 22</value>
-  </data>
-  <data name="comboMiniParseSortType.Location" type="System.Drawing.Point, System.Drawing">
-    <value>156, 121</value>
-  </data>
-  <data name="comboMiniParseSortType.Size" type="System.Drawing.Size, System.Drawing">
-    <value>447, 21</value>
-  </data>
-  <data name="nudMaxFrameRate.Location" type="System.Drawing.Point, System.Drawing">
-    <value>156, 145</value>
-  </data>
-  <data name="nudMaxFrameRate.Size" type="System.Drawing.Size, System.Drawing">
-    <value>447, 20</value>
-  </data>
-  <data name="label13.Location" type="System.Drawing.Point, System.Drawing">
-    <value>158, 238</value>
-  </data>
-  <data name="label13.Size" type="System.Drawing.Size, System.Drawing">
-    <value>443, 88</value>
-  </data>
-  <data name="label7.Location" type="System.Drawing.Point, System.Drawing">
-    <value>3, 168</value>
-  </data>
-  <data name="label7.Size" type="System.Drawing.Size, System.Drawing">
-    <value>149, 24</value>
-  </data>
-  <data name="label8.Location" type="System.Drawing.Point, System.Drawing">
-    <value>3, 192</value>
-  </data>
-  <data name="label8.Size" type="System.Drawing.Size, System.Drawing">
-    <value>149, 24</value>
-  </data>
-  <data name="checkEnableGlobalHotkey.Location" type="System.Drawing.Point, System.Drawing">
-    <value>158, 171</value>
-  </data>
-  <data name="checkEnableGlobalHotkey.Size" type="System.Drawing.Size, System.Drawing">
-    <value>443, 18</value>
-  </data>
-  <data name="textGlobalHotkey.Location" type="System.Drawing.Point, System.Drawing">
-    <value>156, 193</value>
-  </data>
-  <data name="textGlobalHotkey.Size" type="System.Drawing.Size, System.Drawing">
-    <value>447, 20</value>
-  </data>
-  <data name="label9.Location" type="System.Drawing.Point, System.Drawing">
-    <value>3, 48</value>
-  </data>
-  <data name="label9.Size" type="System.Drawing.Size, System.Drawing">
-    <value>149, 24</value>
-  </data>
   <data name="label9.Text" xml:space="preserve">
-    <value>移動とリサイズを制限する</value>
-  </data>
-  <data name="checkLock.Location" type="System.Drawing.Point, System.Drawing">
-    <value>158, 51</value>
-  </data>
-  <data name="checkLock.Size" type="System.Drawing.Size, System.Drawing">
-    <value>443, 18</value>
-  </data>
-  <data name="label10.Location" type="System.Drawing.Point, System.Drawing">
-    <value>3, 216</value>
-  </data>
-  <data name="label10.Size" type="System.Drawing.Size, System.Drawing">
-    <value>149, 22</value>
-  </data>
-  <data name="comboHotkeyType.Location" type="System.Drawing.Point, System.Drawing">
-    <value>156, 217</value>
-  </data>
-  <data name="comboHotkeyType.Size" type="System.Drawing.Size, System.Drawing">
-    <value>447, 21</value>
-  </data>
-  <data name="tableLayoutPanel1.Size" type="System.Drawing.Size, System.Drawing">
-    <value>604, 388</value>
-  </data>
-  <data name="$this.AutoScaleDimensions" type="System.Drawing.SizeF, System.Drawing">
-    <value>6, 13</value>
-  </data>
-  <data name="$this.Size" type="System.Drawing.Size, System.Drawing">
-    <value>604, 388</value>
+    <value>オーバーレイをロックする</value>
   </data>
   <data name="checkActwsCompatbility.Text" xml:space="preserve">
     <value>このオーバーレイはACTWebSocketが必要</value>
@@ -324,5 +170,28 @@
   </data>
   <data name="lblNoFocus.Text" xml:space="preserve">
     <value>フォーカスの無効</value>
+  </data>
+  <data name="btnAddHotkey.Text" xml:space="preserve">
+    <value>ホットキー追加</value>
+  </data>
+  <data name="btnApplyHotkeyChanges.Text" xml:space="preserve">
+    <value>変更を適用</value>
+  </data>
+  <data name="btnRemoveHotkey.Text" xml:space="preserve">
+    <value>選択されたホットキーを削除</value>
+  </data>
+  <data name="label10.Text" xml:space="preserve">
+    <value>オーバーレイをロックすると、サイズと位置が固定されます。</value>
+  </data>
+  <data name="label13.Text" xml:space="preserve">
+    <value>オーバーレイが隠れているときに
+ミュートにする</value>
+  </data>
+  <data name="label7.Text" xml:space="preserve">
+    <value>オーバレイを有効にする</value>
+  </data>
+  <data name="label8.Text" xml:space="preserve">
+    <value>オーバーレイを「無効」にすると、CPUの使用量は減りますが、サウンドの再生等の実行中のすべての動作が停止します。
+オーバーレイを「非表示」にすると、オーバーレイが非表示になるだけです。サウンドの再生や統計情報の収集等のバックグラウンド処理は実行されます。</value>
   </data>
 </root>


### PR DESCRIPTION
- Remove Locaton/Size props.
- Update ja-jp translations.

MiniParseConfigPanel.ja-JP.resx contained Location/Size props, so the UI was quite broken in a Japanese environment.
For Japanese users, it would be nice to be able to increase the version number after the merge and encourage updates.