### PR TITLE
Add handlers for saveData/loadData

### DIFF
--- a/OverlayPlugin.Core/EventSources/MiniParseEventSource.cs
+++ b/OverlayPlugin.Core/EventSources/MiniParseEventSource.cs
@@ -73,6 +73,29 @@ namespace RainbowMage.OverlayPlugin.EventSources
                 });
             });
 
+            RegisterEventHandler("saveData", (msg) => {
+                var key = msg["key"].ToString();
+                if (key == null)
+                    return null;
+
+                Config.OverlayData[key] = msg["data"];
+                return null;
+            });
+
+            RegisterEventHandler("loadData", (msg) => {
+                var key = msg["key"].ToString();
+                if (key == null)
+                    return null;
+
+                if (!Config.OverlayData.ContainsKey(key))
+                    return null;
+
+                var ret = new JObject();
+                ret["key"] = key;
+                ret["data"] = Config.OverlayData[key];
+                return ret;
+            });
+
             ActGlobals.oFormActMain.BeforeLogLineRead += LogLineHandler;
             NetworkParser.OnOnlineStatusChanged += (o, e) =>
             {

--- a/OverlayPlugin.Core/EventSources/MiniParseEventSourceConfig.cs
+++ b/OverlayPlugin.Core/EventSources/MiniParseEventSourceConfig.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Collections.Generic;
 using Newtonsoft.Json.Linq;
 
 namespace RainbowMage.OverlayPlugin.EventSources
@@ -96,6 +97,9 @@ namespace RainbowMage.OverlayPlugin.EventSources
             }
         }
 
+        // Data that overlays can save/load via event handlers.
+        public Dictionary<string, JToken> OverlayData = new Dictionary<string, JToken>();
+
         public MiniParseEventSourceConfig()
         {
             this.updateInterval = 1;
@@ -136,6 +140,11 @@ namespace RainbowMage.OverlayPlugin.EventSources
                 if (obj.TryGetValue("UpdateDpsDuringImport", out value))
                 {
                     result.updateDpsDuringImport = value.ToObject<bool>();
+                }
+
+                if (obj.TryGetValue("OverlayData", out value))
+                {
+                    result.OverlayData = value.ToObject<Dictionary<string, JToken>>();
                 }
             }
 


### PR DESCRIPTION
Usage:
callOverlayHandler({ call: 'saveData', key: someKey, data: someData });
callOverlayHandler({ call: 'loadData', key: someKey }) => (e) => { e.data }

Saves this information in the RainbowMage.OverlayPlugin.config.json file.
Invalid values (functions etc) just get dropped.

Future niceness here would be to forcibly update the config file on disk
in case ACT crashes and doesn't have a chance to save during quit.