### PR TITLE
Update target/charmap/enmity signatures and offsets for patch 5.2

### DIFF
--- a/OverlayPlugin.Core/EventSources/EnmityEventSource.cs
+++ b/OverlayPlugin.Core/EventSources/EnmityEventSource.cs
@@ -70,7 +70,7 @@ namespace RainbowMage.OverlayPlugin.EventSources
                 if (targetData)
                 {
                     // See CreateTargetData() below
-                    //this.DispatchEvent(CreateTargetData(combatants));
+                    this.DispatchEvent(CreateTargetData(combatants));
                 }
                 if (aggroList)
                 {
@@ -107,8 +107,6 @@ namespace RainbowMage.OverlayPlugin.EventSources
 
         internal JObject CreateTargetData(List<Combatant> combatants)
         {
-            // TODO: Update the following code for the new memory structure
-
             EnmityTargetDataObject enmity = new EnmityTargetDataObject();
             try
             {

--- a/OverlayPlugin.Core/EventSources/EnmityMemory.cs
+++ b/OverlayPlugin.Core/EventSources/EnmityMemory.cs
@@ -34,6 +34,7 @@ namespace RainbowMage.OverlayPlugin.EventSources
         public Single PosX;
         public Single PosY;
         public Single PosZ;
+        public Single Rotation;
 
         public string Distance;
         public byte EffectiveDistance;
@@ -101,26 +102,26 @@ namespace RainbowMage.OverlayPlugin.EventSources
         private IntPtr enmityAddress = IntPtr.Zero;
         private IntPtr aggroAddress = IntPtr.Zero;
 
-        private const string charmapSignature = "574883EC??488B1D????????488BF233D2";
-        private const string targetSignature = "483935????????7520483935????????7517";
+        private const string charmapSignature = "48c1ea0381faa7010000????8bc2488d0d";
+        private const string targetSignature = "e8f2652f0084c00f8591010000488d0d";
         private const string enmitySignature = "83f9ff7412448b048e8bd3488d0d";
 
         // Offsets from the signature to find the correct address.
         private const int charmapSignatureOffset = 0;
-        private const int targetSignatureOffset = 192;
+        private const int targetSignatureOffset = 0;
         private const int enmitySignatureOffset = -4648;
 
         // Offset from the enmityAddress to find various enmity data structures.
         private const int aggroEnmityOffset = 0x908;
 
         // Offsets from the targetAddress to find the correct target type.
-        private const int targetTargetOffset = -0x18;
-        private const int focusTargetOffset = 0x38;
-        private const int hoverTargetOffset = 0x20;
+        private const int targetTargetOffset = 176;
+        private const int focusTargetOffset = 184;
+        private const int hoverTargetOffset = 248;
 
         // Constants.
         private const uint emptyID = 0xE0000000;
-        private const int numMemoryCombatants = 344;
+        private const int numMemoryCombatants = 421;
 
         public EnmityMemory(ILogger logger)
         {
@@ -177,7 +178,7 @@ namespace RainbowMage.OverlayPlugin.EventSources
 
             /// CHARMAP
             List<IntPtr> list = memory.SigScan(charmapSignature, 0, bRIP);
-            if (list != null && list.Count == 1)
+            if (list != null && list.Count > 0)
             {
                 charmapAddress = list[0] + charmapSignatureOffset;
             }
@@ -190,7 +191,7 @@ namespace RainbowMage.OverlayPlugin.EventSources
 
             // ENMITY
             list = memory.SigScan(enmitySignature, 0, bRIP);
-            if (list != null && list.Count == 1)
+            if (list != null && list.Count > 0)
             {
                 enmityAddress = list[0] + enmitySignatureOffset;
                 aggroAddress = IntPtr.Add(enmityAddress, aggroEnmityOffset);
@@ -206,7 +207,7 @@ namespace RainbowMage.OverlayPlugin.EventSources
 
             /// TARGET
             list = memory.SigScan(targetSignature, 0, bRIP);
-            if (list != null && list.Count == 1)
+            if (list != null && list.Count > 0)
             {
                 targetAddress = list[0] + targetSignatureOffset;
             }
@@ -351,19 +352,22 @@ namespace RainbowMage.OverlayPlugin.EventSources
             [FieldOffset(0xA8)]
             public Single PosZ;
 
-            [FieldOffset(0x1820)]
+            [FieldOffset(0xB0)]
+            public Single Rotation;
+
+            [FieldOffset(0x17F8)]
             public uint TargetID;
 
-            [FieldOffset(0x18B8)]
+            [FieldOffset(0x1898)]
             public int CurrentHP;
 
-            [FieldOffset(0x18BC)]
+            [FieldOffset(0x189C)]
             public int MaxHP;
 
-            [FieldOffset(0x18F4)]
+            [FieldOffset(0x18D6)]
             public byte Job;
 
-            [FieldOffset(0x1978)]
+            [FieldOffset(0x1958)]
             public fixed byte Effects[effectBytes];
         }
 
@@ -409,6 +413,7 @@ namespace RainbowMage.OverlayPlugin.EventSources
                     PosX = mem.PosX,
                     PosY = mem.PosY,
                     PosZ = mem.PosZ,
+                    Rotation = mem.Rotation,
                     TargetID = mem.TargetID,
                     CurrentHP = mem.CurrentHP,
                     MaxHP = mem.MaxHP,

--- a/OverlayPlugin.Core/EventSources/EnmityMemory.cs
+++ b/OverlayPlugin.Core/EventSources/EnmityMemory.cs
@@ -114,8 +114,8 @@ namespace RainbowMage.OverlayPlugin.EventSources
 
         // Offsets from the targetAddress to find the correct target type.
         private const int targetTargetOffset = 176;
-        private const int focusTargetOffset = 184;
-        private const int hoverTargetOffset = 248;
+        private const int focusTargetOffset = 248;
+        private const int hoverTargetOffset = 208;
 
         // Constants.
         private const uint emptyID = 0xE0000000;

--- a/OverlayPlugin.Core/EventSources/EnmityMemory.cs
+++ b/OverlayPlugin.Core/EventSources/EnmityMemory.cs
@@ -109,10 +109,8 @@ namespace RainbowMage.OverlayPlugin.EventSources
         // Offsets from the signature to find the correct address.
         private const int charmapSignatureOffset = 0;
         private const int targetSignatureOffset = 0;
-        private const int enmitySignatureOffset = -4648;
-
-        // Offset from the enmityAddress to find various enmity data structures.
-        private const int aggroEnmityOffset = 0x908;
+        private const int enmitySignatureOffset = -2608;
+        private const int aggroEnmityOffset = -2336;
 
         // Offsets from the targetAddress to find the correct target type.
         private const int targetTargetOffset = 176;
@@ -193,8 +191,8 @@ namespace RainbowMage.OverlayPlugin.EventSources
             list = memory.SigScan(enmitySignature, 0, bRIP);
             if (list != null && list.Count > 0)
             {
-                enmityAddress = list[0] + enmitySignatureOffset;
-                aggroAddress = IntPtr.Add(enmityAddress, aggroEnmityOffset);
+                enmityAddress = IntPtr.Add(list[0], enmitySignatureOffset);
+                aggroAddress = IntPtr.Add(list[0], aggroEnmityOffset);
             }
             else
             {
@@ -220,6 +218,7 @@ namespace RainbowMage.OverlayPlugin.EventSources
 
             logger.Log(LogLevel.Debug, "charmapAddress: 0x{0:X}", charmapAddress.ToInt64());
             logger.Log(LogLevel.Debug, "enmityAddress: 0x{0:X}", enmityAddress.ToInt64());
+            logger.Log(LogLevel.Debug, "aggroAddress: 0x{0:X}", aggroAddress.ToInt64());
             logger.Log(LogLevel.Debug, "targetAddress: 0x{0:X}", targetAddress.ToInt64());
             Combatant c = GetSelfCombatant();
             if (c != null)
@@ -429,28 +428,27 @@ namespace RainbowMage.OverlayPlugin.EventSources
             }
         }
 
-        [StructLayout(LayoutKind.Explicit, Size=72)]
+        [StructLayout(LayoutKind.Explicit, Size=8)]
         struct EnmityListEntry
         {
             public static int Size => Marshal.SizeOf(typeof(EnmityListEntry));
 
-            [FieldOffset(0x38)]
+            [FieldOffset(0x00)]
             public uint ID;
 
-            [FieldOffset(0x3C)]
+            [FieldOffset(0x04)]
             public uint Enmity;
         }
 
         // A byte[] -> EnmityListEntry[] converter.
         // Owns the memory and returns out EnmityListEntry objects from it.
-        // Both the enmity list and the aggro list use this same structure.
         private class EnmityList
         {
             public int numEntries = 0;
             private byte[] buffer;
 
-            public const short maxEntries = 31;
-            public const int numEntryOffset = 0x8F8;
+            public const short maxEntries = 31; // or 32?
+            public const int numEntryOffset = 256;
             // The number of entries is a short at the end of the array of entries.  Hence, +2.
             public const int totalBytesSize = numEntryOffset + 2;
 
@@ -512,6 +510,53 @@ namespace RainbowMage.OverlayPlugin.EventSources
             return result;
         }
 
+        [StructLayout(LayoutKind.Explicit, Size = 72)]
+        struct AggroListEntry
+        {
+            public static int Size => Marshal.SizeOf(typeof(AggroListEntry));
+
+            [FieldOffset(0x38)]
+            public uint ID;
+
+            [FieldOffset(0x3C)]
+            public uint Enmity;
+        }
+
+        // A byte[] -> AggroListEntry[] converter.
+        // Owns the memory and returns out AggroListEntry objects from it.
+        private class AggroList
+        {
+            public int numEntries = 0;
+            private byte[] buffer;
+
+            public const short maxEntries = 31;
+            public const int numEntryOffset = 0x8F8;
+            // The number of entries is a short at the end of the array of entries.  Hence, +2.
+            public const int totalBytesSize = numEntryOffset + 2;
+
+            public unsafe AggroListEntry GetEntry(int i)
+            {
+                fixed (byte* p = buffer)
+                {
+                    return *(AggroListEntry*)&p[i * AggroListEntry.Size];
+                }
+            }
+
+            public unsafe AggroList(byte[] buffer)
+            {
+                Debug.Assert(maxEntries * AggroListEntry.Size <= totalBytesSize);
+                Debug.Assert(buffer.Length >= totalBytesSize);
+
+                this.buffer = buffer;
+                fixed (byte* p = buffer) numEntries = Math.Min((short)p[numEntryOffset], maxEntries);
+            }
+        }
+
+        private AggroList ReadAggroList(IntPtr address)
+        {
+            return new AggroList(memory.GetByteArray(address, AggroList.totalBytesSize));
+        }
+
         // Converts an EnmityList into a List<AggroEntry>.
         public unsafe List<AggroEntry> GetAggroList(List<Combatant> combatantList)
         {
@@ -526,10 +571,10 @@ namespace RainbowMage.OverlayPlugin.EventSources
 
             var result = new List<AggroEntry>();
 
-            EnmityList list = ReadEnmityList(aggroAddress);
+            AggroList list = ReadAggroList(aggroAddress);
             for (int i = 0; i < list.numEntries; i++)
             {
-                EnmityListEntry e = list.GetEntry(i);
+                AggroListEntry e = list.GetEntry(i);
                 if (e.ID <= 0)
                     continue;
                 Combatant c = combatantList.Find(x => x.ID == e.ID);


### PR DESCRIPTION
## Update target signature/offset
- Updated to the same signature / offset as FFXIV_ACT_Plugin except for Hover Offset.

## Update charmap signature/offset
- Updated to the same signature / offset as FFXIV_ACT_Plugin except for TargetID Offset.
TargetID offset is set NPCTargetID2 so that Target-of-Target can be obtained.

## Update enmity signature/offset
- AggroList and EnmityList classes were split because their structures were different.
- Enmity Value read by EnmityList Class is now a relative value. 
There was no absolute value information in memory.