### PR TITLE
Add new getCombatants event+handler for overlays

### DIFF
--- a/OverlayPlugin.Core/EventSources/MiniParseEventSource.cs
+++ b/OverlayPlugin.Core/EventSources/MiniParseEventSource.cs
@@ -90,7 +90,7 @@ namespace RainbowMage.OverlayPlugin.EventSources
                 OnlineStatusChangedEvent,
                 PartyChangedEvent,
             });
-            
+
             RegisterEventHandler("getLanguage", (msg) => {
                 var lang = FFXIVRepository.GetLanguage();
                 return JObject.FromObject(new
@@ -188,8 +188,10 @@ namespace RainbowMage.OverlayPlugin.EventSources
 
             var combatants = FFXIVRepository.GetCombatants();
 
-            foreach (var combatant in combatants) {
-                if (combatant.ID == 0) {
+            foreach (var combatant in combatants)
+            {
+                if (combatant.ID == 0)
+                {
                     continue;
                 }
                 
@@ -197,19 +199,27 @@ namespace RainbowMage.OverlayPlugin.EventSources
 
                 var combatantName = CachedCombatantPropertyInfos["Name"].GetValue(combatant);
                 
-                if (ids.Count == 0 && names.Count == 0) {
+                if (ids.Count == 0 && names.Count == 0)
+                {
                     include = true;
-                } else {
-                    foreach (var id in ids) {
-                        if (combatant.ID == id) {
+                }
+                else
+                {
+                    foreach (var id in ids)
+                    {
+                        if (combatant.ID == id)
+                        {
                             include = true;
                             break;
                         }
                     }
 
-                    if (!include) {
-                        foreach (var name in names) {
-                            if (combatantName.Equals(name)) {
+                    if (!include)
+                    {
+                        foreach (var name in names)
+                        {
+                            if (combatantName.Equals(name))
+                            {
                                 include = true;
                                 break;
                             }
@@ -217,16 +227,23 @@ namespace RainbowMage.OverlayPlugin.EventSources
                     }
                 }
 
-                if (include) {
+                if (include)
+                {
                     Dictionary<string, object> filteredCombatant = new Dictionary<string, object>();
-                    if (props.Count > 0) {
-                        foreach (var prop in props) {
-                            if (CachedCombatantPropertyInfos.ContainsKey(prop)) {
+                    if (props.Count > 0)
+                    {
+                        foreach (var prop in props)
+                        {
+                            if (CachedCombatantPropertyInfos.ContainsKey(prop))
+                            {
                                 filteredCombatant.Add(prop, CachedCombatantPropertyInfos[prop].GetValue(combatant));
                             }
                         }
-                    } else {
-                        foreach(var prop in CachedCombatantPropertyInfos.Keys) {
+                    }
+                    else
+                    {
+                        foreach (var prop in CachedCombatantPropertyInfos.Keys)
+                        {
                             filteredCombatant.Add(prop, CachedCombatantPropertyInfos[prop].GetValue(combatant));
                         }
                     }

--- a/OverlayPlugin.Core/EventSources/MiniParseEventSource.cs
+++ b/OverlayPlugin.Core/EventSources/MiniParseEventSource.cs
@@ -55,25 +55,6 @@ namespace RainbowMage.OverlayPlugin.EventSources
             "Heading"
         };
 
-        private enum CombatantType : byte
-        {
-            None = 0x00,
-            Player = 0x01,
-            BattleNpc = 0x02,
-            EventNpc = 0x03,
-            Treasure = 0x04,
-            Aetheryte = 0x05,
-            GatheringPoint = 0x06,
-            EventObj = 0x07,
-            MountType = 0x08,
-            Companion = 0x09, // this probably actually means minion
-            Retainer = 0x0A,
-            Area = 0x0B,
-            Housing = 0x0C,
-            Cutscene = 0x0D,
-            CardStand = 0x0E,
-        };
-
         private Dictionary<string, System.Reflection.PropertyInfo> CachedCombatantPropertyInfos
             = new Dictionary<string, System.Reflection.PropertyInfo>();
 


### PR DESCRIPTION
This commit is an alternative to #95, which allows combatant data to be fetched on-demand instead of as a timed event. This is meant to be accessed via, for example, https://github.com/quisquous/cactbot timeline triggers.

All three parameters (`ids`, `names`, and `props`) are currently optional.

Excluding or passing in an empty list of `ids` and `names` will cause all valid combatants to be returned. Including at least one value for `ids` or `names` will cause the list to be filtered to only actors that match at least one of the passed in `ids` or `names`.

Excluding or passing in an empty list of `props` will cause all combatant information to be passed back. Otherwise the data passed back to the overlay will only include the passed in parameters.