### PR TITLE
enmity memory for cn&kr

### DIFF
--- a/OverlayPlugin.Core/EventSources/EnmityEventSource.cs
+++ b/OverlayPlugin.Core/EventSources/EnmityEventSource.cs
@@ -26,10 +26,27 @@ namespace RainbowMage.OverlayPlugin.EventSources
         public EnmityEventSource(ILogger logger) : base(logger)
         {
             // this.memory = new EnmityMemory(logger);
-            memoryCandidates = new List<EnmityMemory>()
+            if(FFXIVRepository.GetLanguage() == FFXIV_ACT_Plugin.Common.Language.Chinese)
             {
-                new EnmityMemory52(logger), new EnmityMemory50(logger)
-            };
+                memoryCandidates = new List<EnmityMemory>()
+                {
+                    new EnmityMemory50(logger)
+                };
+            }
+            else if (FFXIVRepository.GetLanguage() == FFXIV_ACT_Plugin.Common.Language.Korean)
+            {
+                memoryCandidates = new List<EnmityMemory>()
+                {
+                    new EnmityMemory50(logger)
+                };
+            }
+            else
+            {
+                memoryCandidates = new List<EnmityMemory>()
+                {
+                    new EnmityMemory52(logger), new EnmityMemory50(logger)
+                };
+            }
 
             RegisterEventTypes(new List<string> {
                 EnmityTargetDataEvent, EnmityAggroListEvent,


### PR DESCRIPTION
Though the memory signatures of 5.2 can be found in current CN&KR server, the memory structure is not the same. Since cactbot is going to change the target change event to OverlayPlugin's enmity event as we talked in https://github.com/quisquous/cactbot/pull/1388#issuecomment-620707297, I think it's better to support different clients in advance.

What's more, the downloaded SDK of 2.0.4.0 has no `Chinese` or `Korean` enum in `FFXIV_ACT_Plugin.Common.Language`, so we need to update the dependency of `FFXIV_ACT_Plugin.Common` to the latest (or near the latest). Maybe we can use the SDK from https://github.com/ravahn/FFXIV_ACT_Plugin/blob/master/Releases/FFXIV_ACT_Plugin_SDK_2.0.5.9.zip.

I tested most of the memories in CN server, the enmity module can work well but the hover for target info is not working, probably it's changed from 5.0 to current CN patch 5.15? So I'm thinking whether it's better to have an `EnmityMemoryCn` and `EnmityMemoryKr` for different clients.

I have no access to KR server so I cannot test there.