### PR TITLE
Add overlay resources for target bars

### DIFF
--- a/OverlayPlugin.Core/OverlayPlugin.Core.csproj
+++ b/OverlayPlugin.Core/OverlayPlugin.Core.csproj
@@ -219,6 +219,9 @@
     <Content Include="resources\enmity\targetinfo_mini.html">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </Content>
+    <Content Include="resources\enmity_target_funcs.js">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </Content>
     <Content Include="resources\label.html">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </Content>

--- a/OverlayPlugin.Core/OverlayPlugin.Core.csproj
+++ b/OverlayPlugin.Core/OverlayPlugin.Core.csproj
@@ -234,6 +234,24 @@
     <Content Include="resources\spelltimer.html">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </Content>
+    <Content Include="resources\targetbars\focus_target.html">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </Content>
+    <Content Include="resources\targetbars\hover_target.html">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </Content>
+    <Content Include="resources\targetbars\target.html">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </Content>
+    <Content Include="resources\targetbars\targetbars.css">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </Content>
+    <Content Include="resources\targetbars\targetbars.js">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </Content>
+    <Content Include="resources\targetbars\target_of_target.html">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </Content>
   </ItemGroup>
   <ItemGroup>
     <EmbeddedResource Include="Controls\ControlPanel.de-DE.resx">

--- a/OverlayPlugin.Core/resources/enmity/enmity_absolute.html
+++ b/OverlayPlugin.Core/resources/enmity/enmity_absolute.html
@@ -61,6 +61,7 @@
   <!-- load js -->
   <script src="https://unpkg.com/vue@0.12.7/dist/vue.min.js"></script>
   <script src="https://ngld.github.io/OverlayPlugin/assets/shared/common.min.js"></script>
+  <script src="../enmity_target_funcs.js"></script>
   <script src="js/funcs.js"></script>
   <script src="js/enmity.js"></script>
 </body>

--- a/OverlayPlugin.Core/resources/enmity/enmity_absolute_show_only_monsters.html
+++ b/OverlayPlugin.Core/resources/enmity/enmity_absolute_show_only_monsters.html
@@ -61,6 +61,7 @@
   <!-- load js -->
   <script src="https://unpkg.com/vue@0.12.7/dist/vue.min.js"></script>
   <script src="https://ngld.github.io/OverlayPlugin/assets/shared/common.min.js"></script>
+  <script src="../enmity_target_funcs.js"></script>
   <script src="js/funcs.js"></script>
   <script src="js/enmity.js"></script>
 </body>

--- a/OverlayPlugin.Core/resources/enmity/enmity_relative.html
+++ b/OverlayPlugin.Core/resources/enmity/enmity_relative.html
@@ -61,6 +61,7 @@
   <!-- load js -->
   <script src="https://unpkg.com/vue@0.12.7/dist/vue.min.js"></script>
   <script src="https://ngld.github.io/OverlayPlugin/assets/shared/common.min.js"></script>
+  <script src="../enmity_target_funcs.js"></script>
   <script src="js/funcs.js"></script>
   <script src="js/enmity.js"></script>
 </body>

--- a/OverlayPlugin.Core/resources/enmity/enmity_relative_show_only_monsters.html
+++ b/OverlayPlugin.Core/resources/enmity/enmity_relative_show_only_monsters.html
@@ -61,6 +61,7 @@
   <!-- load js -->
   <script src="https://unpkg.com/vue@0.12.7/dist/vue.min.js"></script>
   <script src="https://ngld.github.io/OverlayPlugin/assets/shared/common.min.js"></script>
+  <script src="../enmity_target_funcs.js"></script>
   <script src="js/funcs.js"></script>
   <script src="js/enmity.js"></script>
 </body>

--- a/OverlayPlugin.Core/resources/enmity/enmity_relative_simple.html
+++ b/OverlayPlugin.Core/resources/enmity/enmity_relative_simple.html
@@ -44,6 +44,7 @@
   <!-- load js -->
   <script src="https://unpkg.com/vue@0.12.7/dist/vue.min.js"></script>
   <script src="https://ngld.github.io/OverlayPlugin/assets/shared/common.min.js"></script>
+  <script src="../enmity_target_funcs.js"></script>
   <script src="js/funcs.js"></script>
   <script src="js/enmity.js"></script>
 </body>

--- a/OverlayPlugin.Core/resources/enmity/targetinfo_mini.html
+++ b/OverlayPlugin.Core/resources/enmity/targetinfo_mini.html
@@ -48,6 +48,7 @@
   <!-- load js -->
   <script src="https://unpkg.com/vue@0.12.7/dist/vue.min.js"></script>
   <script src="https://ngld.github.io/OverlayPlugin/assets/shared/common.min.js"></script>
+  <script src="../enmity_target_funcs.js"></script>
   <script src="js/funcs.js"></script>
   <script src="js/enmity.js"></script>
 </body>

--- a/OverlayPlugin.Core/resources/enmity_target_funcs.js
+++ b/OverlayPlugin.Core/resources/enmity_target_funcs.js
@@ -1,0 +1,97 @@
+'use strict';
+
+function toTimeString(floatSeconds, language) {
+  let intSeconds = Math.floor(floatSeconds);
+  let minutes = Math.floor(intSeconds / 60);
+  let seconds = intSeconds % 60;
+  let str = '';
+
+  // TODO: handle other languages here!
+  if (minutes > 0)
+    str = minutes + 'm';
+
+  str += seconds + 's';
+  return str;
+}
+
+// Updates each enmity entry with a |RelativeEnmity| field.
+// Returns the player's enmity for this set of entries, or null if not found.
+// |enmity| is the entire object returned from the EnmityTargetData event.
+function updateRelativeEnmity(enmity) {
+  if (enmity.Entries === null)
+    enmity.Entries = [];
+
+  // Entries sorted by enmity, and keys are integers.
+  // If only one, show absolute value (otherwise confusingly 0 for !isMe).
+  let max = 0;
+  if (Object.keys(enmity.Entries).length > 1)
+    max = enmity.Entries[0].isMe ? enmity.Entries[1].Enmity : enmity.Entries[0].Enmity;
+
+  let playerEnmity = null;
+  for (let i = 0; i < enmity.Entries.length; ++i) {
+    let e = enmity.Entries[i];
+    e.RelativeEnmity = e.Enmity - max;
+    if (e.isMe)
+      playerEnmity = e;
+  }
+  return playerEnmity;
+}
+
+// Records hp values of a target over a time period in order to get estimates
+// about time to death for that target.
+class TargetHistory {
+  constructor () {
+    // Throw away entries older than this.
+    this.keepHistoryMs = 30 * 1000;
+    // Sample period between recorded entries.
+    this.samplePeriodMs = 60;
+
+    // Target ID => { hist: [integer hp values], lastUpdated: date }
+    this.targetHistory = {};
+  }
+
+  // Stores info about target; returns seconds until death, null if unknown.
+  // |target| is a top-level Target object from the EnmityTargetData event.
+  // Should be called once per target per update.
+  processTarget(target) {
+    let now = +new Date();
+
+    if (!this.targetHistory[target.ID]) {
+      this.targetHistory[target.ID] = {
+        hist: [],
+        lastUpdated: now,
+      };
+    }
+
+    let h = this.targetHistory[target.ID];
+    if (now - h.lastUpdated > this.samplePeriodMs) {
+      h.lastUpdated = now;
+      // Don't update if hp is unchanged to keep estimate more stable.
+      if (h.hist.length == 0 || h.hist[h.hist.length - 1].hp != target.CurrentHP)
+        h.hist.push({ time: now, hp: target.CurrentHP });
+    }
+
+    // Toss old history events.
+    while (h.hist.length > 0 && now - h.hist[0].time > this.keepHistoryMs)
+      h.hist.shift();
+  }
+
+  // Returns seconds until death, null if unknown.
+  // |target| is a top-level Target object from the EnmityTargetData event.
+  secondsUntilDeath(target) {
+    let h = this.targetHistory[target.ID];
+    if (h.hist.length < 2)
+      return null;
+
+    let first = h.hist[0];
+    let last = h.hist[h.hist.length - 1];
+    let totalSeconds = (last.time - first.time) / 1000;
+
+    // Some enemies regain hp, ignore these.
+    if (first.hp <= last.hp || totalSeconds == 0)
+      return null;
+
+    let dps = (first.hp - last.hp) / totalSeconds;
+    return last.hp / dps;
+  }
+};

--- a/OverlayPlugin.Core/resources/enmity_target_funcs.js
+++ b/OverlayPlugin.Core/resources/enmity_target_funcs.js
@@ -94,4 +94,10 @@ class TargetHistory {
     let dps = (first.hp - last.hp) / totalSeconds;
     return last.hp / dps;
   }
-};
+}
+
+class ExampleTargetHistory extends TargetHistory {
+  secondsUntilDeath(target) {
+    return 23.7;
+  }
+}

--- a/OverlayPlugin.Core/resources/presets.json
+++ b/OverlayPlugin.Core/resources/presets.json
@@ -58,5 +58,29 @@
     "url": "%%/miniparse.html",
     "size": [700, 300],
     "supports": ["modern"]
-  }
+  },
+  "Target Bar": {
+    "type": "MiniParse",
+    "url": "%%/targetbars/target.html",
+    "size": [500, 600],
+    "supports": ["modern"]
+  },
+  "Focus Target Bar": {
+    "type": "MiniParse",
+    "url": "%%/targetbars/focus_target.html",
+    "size": [500, 600],
+    "supports": ["modern"]
+  },
+  "Hover Target Bar": {
+    "type": "MiniParse",
+    "url": "%%/targetbars/hover_target.html",
+    "size": [500, 600],
+    "supports": ["modern"]
+  },
+  "Target of Target Bar": {
+    "type": "MiniParse",
+    "url": "%%/targetbars/target_of_target.html",
+    "size": [500, 600],
+    "supports": ["modern"]
+  },
 }

--- a/OverlayPlugin.Core/resources/targetbars/focus_target.html
+++ b/OverlayPlugin.Core/resources/targetbars/focus_target.html
@@ -1,0 +1,15 @@
+<!DOCTYPE html>
+<html>
+<head>
+  <meta charset="utf-8">
+  <title>focus target bar</title>
+  <link rel="stylesheet" href="targetbars.css">
+  <script src="https://ngld.github.io/OverlayPlugin/assets/shared/common.min.js"></script>
+  <script src="targetbars.js"></script>
+</head>
+<body class="resize-background">
+  <div id="container-focus" class="bar"></div>
+  <div id="settings-container">
+    <div id="settings"></div>
+  </div>
+</body>

--- a/OverlayPlugin.Core/resources/targetbars/focus_target.html
+++ b/OverlayPlugin.Core/resources/targetbars/focus_target.html
@@ -5,6 +5,7 @@
   <title>focus target bar</title>
   <link rel="stylesheet" href="targetbars.css">
   <script src="https://ngld.github.io/OverlayPlugin/assets/shared/common.min.js"></script>
+  <script src="../enmity_target_funcs.js"></script>
   <script src="targetbars.js"></script>
 </head>
 <body class="resize-background">

--- a/OverlayPlugin.Core/resources/targetbars/hover_target.html
+++ b/OverlayPlugin.Core/resources/targetbars/hover_target.html
@@ -5,6 +5,7 @@
   <title>hover target bar</title>
   <link rel="stylesheet" href="targetbars.css">
   <script src="https://ngld.github.io/OverlayPlugin/assets/shared/common.min.js"></script>
+  <script src="../enmity_target_funcs.js"></script>
   <script src="targetbars.js"></script>
 </head>
 <body class="resize-background">

--- a/OverlayPlugin.Core/resources/targetbars/hover_target.html
+++ b/OverlayPlugin.Core/resources/targetbars/hover_target.html
@@ -1,0 +1,15 @@
+<!DOCTYPE html>
+<html>
+<head>
+  <meta charset="utf-8">
+  <title>hover target bar</title>
+  <link rel="stylesheet" href="targetbars.css">
+  <script src="https://ngld.github.io/OverlayPlugin/assets/shared/common.min.js"></script>
+  <script src="targetbars.js"></script>
+</head>
+<body class="resize-background">
+  <div id="container-hover" class="bar"></div>
+  <div id="settings-container">
+    <div id="settings"></div>
+  </div>
+</body>

--- a/OverlayPlugin.Core/resources/targetbars/target.html
+++ b/OverlayPlugin.Core/resources/targetbars/target.html
@@ -1,0 +1,15 @@
+<!DOCTYPE html>
+<html>
+<head>
+  <meta charset="utf-8">
+  <title>target bar</title>
+  <link rel="stylesheet" href="targetbars.css">
+  <script src="https://ngld.github.io/OverlayPlugin/assets/shared/common.min.js"></script>
+  <script src="targetbars.js"></script>
+</head>
+<body class="resize-background">
+  <div id="container-target" class="bar"></div>
+  <div id="settings-container">
+    <div id="settings"></div>
+  </div>
+</body>

--- a/OverlayPlugin.Core/resources/targetbars/target.html
+++ b/OverlayPlugin.Core/resources/targetbars/target.html
@@ -5,6 +5,7 @@
   <title>target bar</title>
   <link rel="stylesheet" href="targetbars.css">
   <script src="https://ngld.github.io/OverlayPlugin/assets/shared/common.min.js"></script>
+  <script src="../enmity_target_funcs.js"></script>
   <script src="targetbars.js"></script>
 </head>
 <body class="resize-background">

--- a/OverlayPlugin.Core/resources/targetbars/target_of_target.html
+++ b/OverlayPlugin.Core/resources/targetbars/target_of_target.html
@@ -1,0 +1,15 @@
+<!DOCTYPE html>
+<html>
+<head>
+  <meta charset="utf-8">
+  <title>target of target bar</title>
+  <link rel="stylesheet" href="targetbars.css">
+  <script src="https://ngld.github.io/OverlayPlugin/assets/shared/common.min.js"></script>
+  <script src="targetbars.js"></script>
+</head>
+<body class="resize-background">
+  <div id="container-targetoftarget" class="bar"></div>
+  <div id="settings-container">
+    <div id="settings"></div>
+  </div>
+</body>

--- a/OverlayPlugin.Core/resources/targetbars/target_of_target.html
+++ b/OverlayPlugin.Core/resources/targetbars/target_of_target.html
@@ -5,6 +5,7 @@
   <title>target of target bar</title>
   <link rel="stylesheet" href="targetbars.css">
   <script src="https://ngld.github.io/OverlayPlugin/assets/shared/common.min.js"></script>
+  <script src="../enmity_target_funcs.js"></script>
   <script src="targetbars.js"></script>
 </head>
 <body class="resize-background">

--- a/OverlayPlugin.Core/resources/targetbars/targetbars.css
+++ b/OverlayPlugin.Core/resources/targetbars/targetbars.css
@@ -1,0 +1,114 @@
+body,
+html {
+  margin: 0;
+  overflow: hidden;
+  font-family: Meiryo, sans-serif;
+  -webkit-app-region: drag;
+}
+
+.hidden {
+  display: none !important;
+}
+
+.rounded {
+  border-radius: 4px;
+}
+
+.bar {
+  padding-left: 10px;
+  padding-right: 10px;
+  display: grid;
+  grid-template-columns: repeat(3, 1fr);
+  white-space: nowrap;
+}
+
+#settings-container {
+  margin: 8px;
+  width: calc(100% - 16px);
+  overflow-y: scroll;
+  overflow-x: hidden;
+  background-color: white;
+  position: absolute;
+  top: 20px;
+  bottom: 0;
+  border: 3px solid grey;
+  box-sizing: border-box;
+}
+
+#settings {
+  display: grid;
+  align-items: center;
+  grid-template-columns: repeat(1, auto auto);
+  grid-gap: 12px;
+  margin: 12px;
+  font-size: 12px;
+  -webkit-app-region: drag;
+}
+
+input {
+  padding: 2px;
+}
+
+.settings-title {
+  grid-column-end: span 2;
+  justify-self: center;
+  font-size: larger;
+  font-weight: bold;
+}
+
+.settings-helptext {
+  grid-column-end: span 2;
+  justify-self: center;
+  color: grey;
+}
+
+.select-container {
+  position: relative;
+  width: 100%;
+}
+
+.select-active {
+  padding: 2px;
+  border: 1px solid grey;
+  height: 100%;
+  cursor: pointer;
+}
+
+.select-active::after {
+  position: absolute;
+  top: 6px;
+  right: 0;
+  content: '';
+  box-sizing: border-box;
+  margin-right: 5px;
+  width: 10px;
+  height: 10px;
+  border-left: 5px solid transparent;
+  border-right: 5px solid transparent;
+  border-top: 10px solid black;
+  border-bottom: none;
+}
+
+.select-items {
+  position: absolute;
+  background-color: white;
+  width: 100%;
+  z-index: 1;
+  box-sizing: border-box;
+  border: 1px solid grey;
+}
+
+.select-item {
+  padding: 2px;
+  height: 100%;
+  cursor: pointer;
+}
+
+.select-item:hover {
+  background-color: rgba(30, 144, 255);
+}
+
+.resize-background {
+  /* not fully transparent to make it easier to move */
+  background-color: rgba(0, 0, 150, 0.2);
+}

--- a/OverlayPlugin.Core/resources/targetbars/targetbars.js
+++ b/OverlayPlugin.Core/resources/targetbars/targetbars.js
@@ -253,6 +253,21 @@ const configStructure = [
   },
 ];
 
+const perTargetOverrides = {
+  Target: {
+    barWidth: 415,
+    leftText: 'CurrentAndMaxHP',
+    middleText: 'TimeToDeath',
+    rightText: 'Distance',
+  },
+  Focus: {
+    barWidth: 210,
+    leftText: 'CurrentAndMaxHP',
+    middleText: 'None',
+    rightText: 'PercentHP',
+  },
+};
+
 // Return "str px" if "str" is a number, otherwise "str".
 function defaultAsPx(str) {
   if (parseFloat(str) == str)
@@ -804,9 +819,14 @@ window.addEventListener('DOMContentLoaded', async (e) => {
 
   // Set option defaults from config.
   let options = {};
-  options[targetType] = options[targetType] || {};
+  options[targetType] = {};
   for (const opt of configStructure)
     options[targetType][opt.id] = opt.default;
+
+  // Handle per target default overrides.
+  const overrides = perTargetOverrides[targetType];
+  for (const key in overrides)
+    options[targetType][key] = overrides[key];
 
   // Overwrite options from loaded values.  Options are stored once per target type,
   // so that different targets can be configured differently.

--- a/OverlayPlugin.Core/resources/targetbars/targetbars.js
+++ b/OverlayPlugin.Core/resources/targetbars/targetbars.js
@@ -1,0 +1,633 @@
+'use strict';
+
+// Map of language -> targetType -> settings title.
+const configTitles = {
+  English: {
+    Target: 'Target Settings',
+    Focus: 'Focus Target Settings',
+    Hover: 'Hover Target Settings',
+    TargetOfTarget: 'Target of Target Settings',
+  },
+};
+
+const helpText = {
+  English: '(🔒lock overlay to hide settings)',
+};
+
+// language -> displayed option text -> text key
+const textOptions = {
+  English: {
+    'None': 'None',
+    'Current HP': 'CurrentHP',
+    'Max HP': 'MaxHP',
+    'Current / Max HP': 'CurrentAndMaxHP',
+    'Percent HP': 'PercentHP',
+    'Distance': 'Distance',
+  },
+};
+
+const configStructure = [
+  {
+    id: 'leftText',
+    name: {
+      English: 'Left Text',
+    },
+    type: 'select',
+    options: textOptions,
+    default: 'CurrentAndMaxHP',
+  },
+  {
+    id: 'middleText',
+    name: {
+      English: 'Middle Text',
+    },
+    options: textOptions,
+    type: 'select',
+    default: 'Distance',
+  },
+  {
+    id: 'rightText',
+    name: {
+      English: 'Right Text',
+    },
+    options: textOptions,
+    type: 'select',
+    default: 'PercentHP',
+  },
+  {
+    id: 'barHeight',
+    name: {
+      English: 'Height of the bar',
+    },
+    type: 'text',
+    default: 11,
+  },
+  {
+    id: 'barWidth',
+    name: {
+      English: 'Width of the bar',
+    },
+    type: 'text',
+    default: 250,
+  },
+  {
+    id: 'isRounded',
+    name: {
+      English: 'Enable rounded corners',
+    },
+    type: 'checkbox',
+    default: true,
+  },
+  {
+    id: 'borderSize',
+    name: {
+      English: 'Size of the border',
+    },
+    type: 'text',
+    default: 1,
+  },
+  {
+    id: 'borderColor',
+    name: {
+      English: 'Color of the border',
+    },
+    type: 'text',
+    default: 'black',
+  },
+  {
+    id: 'fontSize',
+    name: {
+      English: 'Size of the font',
+    },
+    type: 'text',
+    default: 10,
+  },
+  {
+    id: 'fontFamily',
+    name: {
+      English: 'Name of the font',
+    },
+    type: 'text',
+    default: 'Meiryo',
+  },
+  {
+    id: 'fontColor',
+    name: {
+      English: 'Color of the font',
+    },
+    type: 'text',
+    default: 'white',
+  },
+  {
+    id: 'bgColor',
+    name: {
+      English: 'Background depleted bar color',
+    },
+    type: 'text',
+    default: 'rgb(4, 15, 4)',
+  },
+  {
+    id: 'fgColorHigh',
+    name: {
+      English: 'Bar color when hp is high',
+    },
+    type: 'text',
+    default: 'rgb(0, 159, 1)',
+  },
+  {
+    id: 'midColorPercent',
+    name: {
+      English: 'Percent below where hp is mid',
+    },
+    type: 'text',
+    default: 60,
+  },
+  {
+    id: 'fgColorMid',
+    name: {
+      English: 'Bar color when hp is mid',
+    },
+    type: 'text',
+    default: 'rgb(160, 130, 30)',
+  },
+  {
+    id: 'lowColorPercent',
+    name: {
+      English: 'Percent below where hp is mid',
+    },
+    type: 'text',
+    default: 30,
+  },
+  {
+    id: 'fgColorLow',
+    name: {
+      English: 'Bar color when hp is low',
+    },
+    type: 'text',
+    default: 'rgb(240, 40, 30)',
+  },
+];
+
+const overlayDataKey = 'targetbars';
+const targets = ['Target', 'Focus', 'Hover', 'TargetOfTarget'];
+const rawKeys = ['CurrentHP', 'MaxHP', 'Distance'];
+const comboKeys = ['PercentHP', 'CurrentAndMaxHP'];
+const allKeys = rawKeys.concat(comboKeys);
+
+// Return "str px" if "str" is a number, otherwise "str".
+let defaultAsPx = (str) => {
+  if (parseFloat(str) == str)
+    return str + 'px';
+  return str;
+};
+
+class BarUI {
+  constructor(targetType, topLevelOptions, div) {
+    this.target = targetType;
+    this.options = topLevelOptions[targetType];
+    this.div = div;
+    this.lastData = {};
+    this.isExampleShowcase = false;
+
+    // Map of keys to elements that contain those values.
+    // built from this.options.elements.
+    this.elementMap = {};
+
+    const textMap = {
+      left: this.options.leftText,
+      center: this.options.middleText,
+      right: this.options.rightText,
+    };
+    for (const justifyKey in textMap) {
+      let text = textMap[justifyKey];
+      let textDiv = document.createElement('div');
+      textDiv.classList.add(text);
+      textDiv.style.justifySelf = justifyKey;
+      this.div.appendChild(textDiv);
+      this.elementMap[text] = this.elementMap[text] || [];
+      this.elementMap[text].push(textDiv);
+    }
+
+    if (this.options.isRounded)
+      this.div.classList.add('rounded');
+    else
+      this.div.classList.remove('rounded');
+
+    // TODO: could move settings container down by height of bar
+    // but up to some maximum so it's not hidden if you type in
+    // a ridiculous number, vs the absolute position it is now.
+    this.div.style.height = defaultAsPx(this.options.barHeight);
+    this.div.style.width = defaultAsPx(this.options.barWidth);
+
+    let borderStyle = defaultAsPx(this.options.borderSize);
+    borderStyle += ' solid ' + this.options.borderColor;
+    this.div.style.border = borderStyle;
+
+    this.div.style.fontSize = defaultAsPx(this.options.fontSize);
+    this.div.style.fontFamily = this.options.fontFamily;
+    this.div.style.color = this.options.fontColor;
+
+    // Alignment hack:
+    // align-self:center doesn't work when children are taller than parents.
+    // TODO: is there some better way to do this?
+    const containerHeight = parseInt(this.div.clientHeight);
+    for (const el in this.elementMap) {
+      for (let div of this.elementMap[el]) {
+        // Add some text to give div a non-zero height.
+        div.innerText = 'XXX';
+        let divHeight = div.clientHeight;
+        div.innerText = '';
+        if (divHeight <= containerHeight)
+          continue;
+        div.style.position = 'relative';
+        div.style.top = defaultAsPx((containerHeight - divHeight) / 2.0);
+      }
+    }
+  }
+
+  // EnmityTargetData event handler.
+  update(e) {
+    if (!e)
+      return;
+
+    // Don't let the game updates override the example showcase.
+    if (this.isExampleShowcase && !e.isExampleShowcase)
+      return;
+    this.isExampleShowcase = e.isExampleShowcase;
+
+    let data = e[this.target];
+    // If there's no target, or if the target is something like a marketboard
+    // which has zero HP, then don't show the overlay.
+    if (!data || data.MaxHP === 0) {
+      this.setVisible(false);
+      return;
+    }
+
+    for (const key of rawKeys) {
+      if (data[key] !== this.lastData[key])
+        this.setValue(key, data[key]);
+    }
+
+    if (data.CurrentHP !== this.lastData.CurrentHP ||
+      data.MaxHP !== this.lastData.MaxHP) {
+      const percent = 100 * data.CurrentHP / data.MaxHP;
+      const percentStr = percent.toFixed(2) + '%';
+      this.setValue('PercentHP', percentStr);
+      this.updateGradient(percent);
+
+      this.setValue('CurrentAndMaxHP', data.CurrentHP + ' / ' + data.MaxHP);
+    }
+
+    this.lastData = data;
+    this.setVisible(true);
+  }
+
+  updateGradient(percent) {
+    // Find the colors from options, based on current percentage.
+    let fgColor;
+    if (percent > this.options.midColorPercent)
+      fgColor = this.options.fgColorHigh;
+    else if (percent > this.options.lowColorPercent)
+      fgColor = this.options.fgColorMid;
+    else
+      fgColor = this.options.fgColorLow;
+
+    // Right-fill with fgcolor up to percent, and then bgcolor after that.
+    const bgColor = this.options.bgColor;
+    let style = 'linear-gradient(90deg, ' +
+      fgColor + ' ' + percent + '%, ' + bgColor + ' ' + percent + '%)';
+    this.div.style.background = style;
+  }
+
+  setValue(name, value) {
+    let nodes = this.elementMap[name];
+    if (!nodes)
+      return;
+    for (let node of nodes)
+      node.innerText = value;
+  }
+
+  setVisible(isVisible) {
+    if (isVisible)
+      this.div.classList.remove('hidden');
+    else
+      this.div.classList.add('hidden');
+  }
+}
+
+class SettingsUI {
+  constructor(targetType, lang, configStructure, savedConfig, settingsDiv, rebuildFunc) {
+    this.savedConfig = savedConfig || {};
+    this.div = settingsDiv;
+    this.rebuildFunc = rebuildFunc;
+    this.lang = lang;
+    this.target = targetType;
+
+    this.buildUI(settingsDiv, configStructure);
+
+    rebuildFunc(savedConfig);
+  }
+
+  // Top level UI builder, builds everything.
+  buildUI(container, configStructure) {
+    container.appendChild(this.buildHeader());
+    container.appendChild(this.buildHelpText());
+    for (const opt of configStructure) {
+      let buildFunc = {
+        checkbox: this.buildCheckbox,
+        select: this.buildSelect,
+        text: this.buildText,
+      }[opt.type];
+      if (!buildFunc) {
+        console.error('unknown type: ' + JSON.stringify(opt));
+        continue;
+      }
+
+      buildFunc.bind(this)(container, opt, this.target);
+    }
+  }
+
+  buildHeader() {
+    let div = document.createElement('div');
+    const titles = this.translate(configTitles);
+    div.innerHTML = titles[this.target];
+    div.classList.add('settings-title');
+    return div;
+  }
+
+  buildHelpText() {
+    let div = document.createElement('div');
+    div.innerHTML = this.translate(helpText);
+    div.classList.add('settings-helptext');
+    return div;
+  }
+
+  // Code after this point in this class is largely cribbed from cactbot's
+  // ui/config/config.js CactbotConfigurator.
+  // If this gets used again, maybe it should be abstracted.
+
+  async saveConfigData() {
+    await callOverlayHandler({
+      call: 'saveData',
+      key: overlayDataKey,
+      data: this.savedConfig,
+    });
+    this.rebuildFunc(this.savedConfig);
+  }
+
+  // Helper translate function.  Takes in an object with locale keys
+  // and returns a single entry based on available translations.
+  translate(textObj) {
+    if (textObj === null || typeof textObj !== 'object' || !textObj['English'])
+      return textObj;
+    let t = textObj[this.lang];
+    if (t)
+      return t;
+    return textObj['English'];
+  }
+
+  // takes variable args, with the last value being the default value if
+  // any key is missing.
+  // e.g. (foo, bar, baz, 5) with {foo: { bar: { baz: 3 } } } will return
+  // the value 3.  Requires at least two args.
+  getOption() {
+    let num = arguments.length;
+    if (num < 2) {
+      console.error('getOption requires at least two args');
+      return;
+    }
+
+    let defaultValue = arguments[num - 1];
+    let objOrValue = this.savedConfig;
+    for (let i = 0; i < num - 1; ++i) {
+      objOrValue = objOrValue[arguments[i]];
+      if (typeof objOrValue === 'undefined')
+        return defaultValue;
+    }
+
+    return objOrValue;
+  }
+
+  // takes variable args, with the last value being the 'value' to set it to
+  // e.g. (foo, bar, baz, 3) will set {foo: { bar: { baz: 3 } } }.
+  // requires at least two args.
+  setOption() {
+    let num = arguments.length;
+    if (num < 2) {
+      console.error('setOption requires at least two args');
+      return;
+    }
+
+    // Set keys and create default {} if it doesn't exist.
+    let obj = this.savedConfig;
+    for (let i = 0; i < num - 2; ++i) {
+      let arg = arguments[i];
+      obj[arg] = obj[arg] || {};
+      obj = obj[arg];
+    }
+    // Set the last key to have the final argument's value.
+    obj[arguments[num - 2]] = arguments[num - 1];
+    this.saveConfigData();
+  }
+
+  buildNameDiv(opt) {
+    let div = document.createElement('div');
+    div.innerHTML = this.translate(opt.name);
+    div.classList.add('option-name');
+    return div;
+  }
+
+  buildCheckbox(parent, opt, group) {
+    let div = document.createElement('div');
+    div.classList.add('option-input-container');
+
+    let input = document.createElement('input');
+    div.appendChild(input);
+    input.type = 'checkbox';
+    input.checked = this.getOption(group, opt.id, opt.default);
+    input.onchange = () => this.setOption(group, opt.id, input.checked);
+
+    parent.appendChild(this.buildNameDiv(opt));
+    parent.appendChild(div);
+  }
+
+  // <select> inputs don't work in overlays, so make a fake one.
+  buildSelect(parent, opt, group) {
+    let div = document.createElement('div');
+    div.classList.add('option-input-container');
+    div.classList.add('select-container');
+
+    // Build the real select so we have a real input element.
+    let input = document.createElement('select');
+    input.classList.add('hidden');
+    div.appendChild(input);
+
+    let defaultValue = this.getOption(group, opt.id, opt.default);
+    input.onchange = () => this.setOption(group, opt.id, input.value);
+
+    let innerOptions = this.translate(opt.options);
+    for (let key in innerOptions) {
+      let elem = document.createElement('option');
+      elem.value = innerOptions[key];
+      elem.innerHTML = key;
+      if (innerOptions[key] == defaultValue)
+        elem.selected = true;
+      input.appendChild(elem);
+    }
+
+    parent.appendChild(this.buildNameDiv(opt));
+    parent.appendChild(div);
+
+    // Now build the fake select.
+    let selectedDiv = document.createElement('div');
+    selectedDiv.classList.add('select-active');
+    selectedDiv.innerHTML = input.options[input.selectedIndex].innerHTML;
+    div.appendChild(selectedDiv);
+
+    let items = document.createElement('div');
+    items.classList.add('select-items', 'hidden');
+    div.appendChild(items);
+
+    selectedDiv.addEventListener('click', (e) => {
+      items.classList.toggle('hidden');
+    });
+
+    // Popout list of options.
+    for (let idx = 0; idx < input.options.length; ++idx) {
+      let optionElem = input.options[idx];
+      let item = document.createElement('div');
+      item.classList.add('select-item');
+      item.innerHTML = optionElem.innerHTML;
+      items.appendChild(item);
+
+      item.addEventListener('click', (e) => {
+        input.selectedIndex = idx;
+        input.onchange();
+        selectedDiv.innerHTML = item.innerHTML;
+        items.classList.toggle('hidden');
+        selectedDiv.classList.toggle('select-arrow-active');
+      });
+    }
+  }
+
+  buildText(parent, opt, group, step) {
+    let div = document.createElement('div');
+    div.classList.add('option-input-container');
+
+    let input = document.createElement('input');
+    div.appendChild(input);
+    input.type = 'text';
+    if (step)
+      input.step = step;
+    input.value = this.getOption(group, opt.id, opt.default);
+    let setFunc = () => this.setOption(group, opt.id, input.value);
+    input.onchange = setFunc;
+    input.oninput = setFunc;
+
+    parent.appendChild(this.buildNameDiv(opt));
+    parent.appendChild(div);
+  }
+}
+
+function updateOverlayState(e) {
+  let settingsContainer = document.getElementById('settings-container');
+  if (!settingsContainer)
+    return;
+  const locked = e.detail.isLocked;
+  if (locked) {
+    settingsContainer.classList.add('hidden');
+    document.body.classList.remove('resize-background');
+  } else {
+    settingsContainer.classList.remove('hidden');
+    document.body.classList.add('resize-background');
+  }
+  OverlayPluginApi.setAcceptFocus(!locked);
+}
+
+function showExample(barUI) {
+  barUI.update({
+    Target: {
+      Name: 'TargetMob',
+      CurrentHP: 38300,
+      MaxHP: 50000,
+      Distance: 12.8,
+      EffectiveDistance: 7,
+    },
+    Focus: {
+      Name: 'FocusMob',
+      CurrentHP: 8123,
+      MaxHP: 29123,
+      Distance: 52.7,
+      EffectiveDistance: 45,
+    },
+    Hover: {
+      Name: 'HoverMob',
+      CurrentHP: 2300,
+      MaxHP: 2500,
+      Distance: 5.2,
+      EffectiveDistance: 1,
+    },
+    TargetOfTarget: {
+      Name: 'TargetOfTargetMob',
+      CurrentHP: 15123,
+      MaxHP: 32748,
+      Distance: 12.6,
+      EffectiveDistance: 3,
+    },
+    isExampleShowcase: true,
+  });
+}
+
+// This event comes early and doesn't depend on any other state.
+// So, add the listener before DOMContentLoaded.
+document.addEventListener('onOverlayStateUpdate', updateOverlayState);
+
+window.addEventListener('DOMContentLoaded', async (e) => {
+  // Initialize language from OverlayPlugin.
+  let lang = 'English';
+  const langResult = await window.callOverlayHandler({ call: 'getLanguage' });
+  if (langResult && langResult.language)
+    lang = langResult.language;
+
+  // Determine the type of target bar by a specially named container.
+  let containerDiv;
+  let targetType;
+  for (const key of targets) {
+    containerDiv = document.getElementById('container-' + key.toLowerCase());
+    if (containerDiv) {
+      targetType = key;
+      break;
+    }
+  }
+  if (!containerDiv) {
+    console.error('Missing container');
+    return;
+  }
+
+  // Set option defaults from config.
+  let options = {};
+  options[targetType] = options[targetType] || {};
+  for (const opt of configStructure)
+    options[targetType][opt.id] = opt.default;
+
+  // Overwrite options from loaded values.  Options are stored once per target type,
+  // so that different targets can be configured differently.
+  const loadResult = await window.callOverlayHandler({ call: 'loadData', key: overlayDataKey });
+  if (loadResult && loadResult.data)
+    options = Object.assign(options, loadResult.data);
+
+  // Creating settings will build the initial bars UI.
+  // Changes to settings rebuild the bars.
+  let barUI;
+  let settingsDiv = document.getElementById('settings');
+  let buildFunc = (options) => {
+    while (containerDiv.lastChild)
+      containerDiv.removeChild(containerDiv.lastChild);
+    barUI = new BarUI(targetType, options, containerDiv);
+  };
+  let gSettingsUI = new SettingsUI(targetType, lang, configStructure, options, settingsDiv, buildFunc);
+
+  window.addOverlayListener('EnmityTargetData', (e) => barUI.update(e));
+  document.addEventListener('onExampleShowcase', () => showExample(barUI));
+  window.startOverlayEvents();
+});


### PR DESCRIPTION
There are four html pages that are all the same, other than a
differently named container.  The JavaScript finds the container by
name to figure out which target bar type it's supposed to be.
Settings for each bar are stored separately, so they can all be
configured differently.

Much of the settings code is cribbed from cactbot.

The settings UI is pretty lackluster looking, but maybe somebody
else could improve it.  Sorry!

Followups here could be including some of the enmity values
(time to death, enmity, relative enmity) as possible options.