### PR TITLE
fix: chinese config panel layout issues

### DIFF
--- a/OverlayPlugin.Core/Overlays/MiniParseConfigPanel.resx
+++ b/OverlayPlugin.Core/Overlays/MiniParseConfigPanel.resx
@@ -130,10 +130,10 @@
   </data>
   <assembly alias="System.Drawing" name="System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a" />
   <data name="applyPresetCombo.Location" type="System.Drawing.Point, System.Drawing">
-    <value>157, 186</value>
+    <value>157, 172</value>
   </data>
   <data name="applyPresetCombo.Size" type="System.Drawing.Size, System.Drawing">
-    <value>398, 21</value>
+    <value>398, 20</value>
   </data>
   <data name="applyPresetCombo.TabIndex" type="System.Int32, mscorlib">
     <value>41</value>
@@ -154,7 +154,7 @@
     <value>True</value>
   </data>
   <data name="cbMuteHidden.Location" type="System.Drawing.Point, System.Drawing">
-    <value>157, 313</value>
+    <value>157, 289</value>
   </data>
   <data name="cbMuteHidden.Size" type="System.Drawing.Size, System.Drawing">
     <value>15, 14</value>
@@ -178,10 +178,10 @@
     <value>True</value>
   </data>
   <data name="label13.Location" type="System.Drawing.Point, System.Drawing">
-    <value>6, 314</value>
+    <value>6, 290</value>
   </data>
   <data name="label13.Size" type="System.Drawing.Size, System.Drawing">
-    <value>132, 13</value>
+    <value>149, 12</value>
   </data>
   <data name="label13.TabIndex" type="System.Int32, mscorlib">
     <value>39</value>
@@ -205,10 +205,10 @@
     <value>Top, Left, Right</value>
   </data>
   <data name="label10.Location" type="System.Drawing.Point, System.Drawing">
-    <value>157, 146</value>
+    <value>157, 135</value>
   </data>
   <data name="label10.Size" type="System.Drawing.Size, System.Drawing">
-    <value>435, 37</value>
+    <value>435, 34</value>
   </data>
   <data name="label10.TabIndex" type="System.Int32, mscorlib">
     <value>38</value>
@@ -232,10 +232,10 @@
     <value>Top, Left, Right</value>
   </data>
   <data name="label8.Location" type="System.Drawing.Point, System.Drawing">
-    <value>154, 43</value>
+    <value>154, 40</value>
   </data>
   <data name="label8.Size" type="System.Drawing.Size, System.Drawing">
-    <value>438, 57</value>
+    <value>438, 53</value>
   </data>
   <data name="label8.TabIndex" type="System.Int32, mscorlib">
     <value>37</value>
@@ -261,7 +261,7 @@ Hiding an overlay only turns it invisible. It still runs in the background and c
     <value>True</value>
   </data>
   <data name="cbEnableOverlay.Location" type="System.Drawing.Point, System.Drawing">
-    <value>157, 24</value>
+    <value>157, 22</value>
   </data>
   <data name="cbEnableOverlay.Size" type="System.Drawing.Size, System.Drawing">
     <value>15, 14</value>
@@ -285,10 +285,10 @@ Hiding an overlay only turns it invisible. It still runs in the background and c
     <value>True</value>
   </data>
   <data name="label7.Location" type="System.Drawing.Point, System.Drawing">
-    <value>6, 25</value>
+    <value>6, 23</value>
   </data>
   <data name="label7.Size" type="System.Drawing.Size, System.Drawing">
-    <value>77, 13</value>
+    <value>89, 12</value>
   </data>
   <data name="label7.TabIndex" type="System.Int32, mscorlib">
     <value>35</value>
@@ -324,7 +324,7 @@ Hiding an overlay only turns it invisible. It still runs in the background and c
     <value>0, 0, 0, 0</value>
   </data>
   <data name="textMiniParseUrl.Size" type="System.Drawing.Size, System.Drawing">
-    <value>398, 20</value>
+    <value>398, 21</value>
   </data>
   <data name="textMiniParseUrl.TabIndex" type="System.Int32, mscorlib">
     <value>3</value>
@@ -351,7 +351,7 @@ Hiding an overlay only turns it invisible. It still runs in the background and c
     <value>0, 0, 0, 1</value>
   </data>
   <data name="buttonMiniParseSelectFile.Size" type="System.Drawing.Size, System.Drawing">
-    <value>37, 21</value>
+    <value>37, 19</value>
   </data>
   <data name="buttonMiniParseSelectFile.TabIndex" type="System.Int32, mscorlib">
     <value>4</value>
@@ -372,7 +372,7 @@ Hiding an overlay only turns it invisible. It still runs in the background and c
     <value>1</value>
   </data>
   <data name="tableLayoutPanel2.Location" type="System.Drawing.Point, System.Drawing">
-    <value>157, 227</value>
+    <value>157, 210</value>
   </data>
   <data name="tableLayoutPanel2.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
     <value>1, 1, 1, 1</value>
@@ -381,7 +381,7 @@ Hiding an overlay only turns it invisible. It still runs in the background and c
     <value>1</value>
   </data>
   <data name="tableLayoutPanel2.Size" type="System.Drawing.Size, System.Drawing">
-    <value>435, 24</value>
+    <value>435, 22</value>
   </data>
   <data name="tableLayoutPanel2.TabIndex" type="System.Int32, mscorlib">
     <value>27</value>
@@ -408,10 +408,10 @@ Hiding an overlay only turns it invisible. It still runs in the background and c
     <value>NoControl</value>
   </data>
   <data name="label1.Location" type="System.Drawing.Point, System.Drawing">
-    <value>6, 230</value>
+    <value>6, 212</value>
   </data>
   <data name="label1.Size" type="System.Drawing.Size, System.Drawing">
-    <value>29, 13</value>
+    <value>23, 12</value>
   </data>
   <data name="label1.TabIndex" type="System.Int32, mscorlib">
     <value>26</value>
@@ -444,7 +444,7 @@ Hiding an overlay only turns it invisible. It still runs in the background and c
     <value>6, 3</value>
   </data>
   <data name="label3.Size" type="System.Drawing.Size, System.Drawing">
-    <value>71, 13</value>
+    <value>77, 12</value>
   </data>
   <data name="label3.TabIndex" type="System.Int32, mscorlib">
     <value>0</value>
@@ -474,7 +474,7 @@ Hiding an overlay only turns it invisible. It still runs in the background and c
     <value>NoControl</value>
   </data>
   <data name="checkLock.Location" type="System.Drawing.Point, System.Drawing">
-    <value>157, 125</value>
+    <value>157, 115</value>
   </data>
   <data name="checkLock.Size" type="System.Drawing.Size, System.Drawing">
     <value>15, 14</value>
@@ -528,10 +528,10 @@ Hiding an overlay only turns it invisible. It still runs in the background and c
     <value>NoControl</value>
   </data>
   <data name="label9.Location" type="System.Drawing.Point, System.Drawing">
-    <value>6, 125</value>
+    <value>6, 115</value>
   </data>
   <data name="label9.Size" type="System.Drawing.Size, System.Drawing">
-    <value>68, 13</value>
+    <value>77, 12</value>
   </data>
   <data name="label9.TabIndex" type="System.Int32, mscorlib">
     <value>23</value>
@@ -561,10 +561,10 @@ Hiding an overlay only turns it invisible. It still runs in the background and c
     <value>NoControl</value>
   </data>
   <data name="label2.Location" type="System.Drawing.Point, System.Drawing">
-    <value>6, 103</value>
+    <value>6, 95</value>
   </data>
   <data name="label2.Size" type="System.Drawing.Size, System.Drawing">
-    <value>101, 13</value>
+    <value>119, 12</value>
   </data>
   <data name="label2.TabIndex" type="System.Int32, mscorlib">
     <value>0</value>
@@ -594,7 +594,7 @@ Hiding an overlay only turns it invisible. It still runs in the background and c
     <value>NoControl</value>
   </data>
   <data name="checkMiniParseClickthru.Location" type="System.Drawing.Point, System.Drawing">
-    <value>157, 103</value>
+    <value>157, 95</value>
   </data>
   <data name="checkMiniParseClickthru.Size" type="System.Drawing.Size, System.Drawing">
     <value>15, 14</value>
@@ -621,10 +621,10 @@ Hiding an overlay only turns it invisible. It still runs in the background and c
     <value>NoControl</value>
   </data>
   <data name="label4.Location" type="System.Drawing.Point, System.Drawing">
-    <value>6, 255</value>
+    <value>6, 235</value>
   </data>
   <data name="label4.Size" type="System.Drawing.Size, System.Drawing">
-    <value>122, 13</value>
+    <value>137, 12</value>
   </data>
   <data name="label4.TabIndex" type="System.Int32, mscorlib">
     <value>32</value>
@@ -654,7 +654,7 @@ Hiding an overlay only turns it invisible. It still runs in the background and c
     <value>NoControl</value>
   </data>
   <data name="cbWhiteBg.Location" type="System.Drawing.Point, System.Drawing">
-    <value>157, 255</value>
+    <value>157, 235</value>
   </data>
   <data name="cbWhiteBg.Size" type="System.Drawing.Size, System.Drawing">
     <value>15, 14</value>
@@ -681,10 +681,10 @@ Hiding an overlay only turns it invisible. It still runs in the background and c
     <value>NoControl</value>
   </data>
   <data name="label12.Location" type="System.Drawing.Point, System.Drawing">
-    <value>154, 272</value>
+    <value>154, 251</value>
   </data>
   <data name="label12.Size" type="System.Drawing.Size, System.Drawing">
-    <value>331, 13</value>
+    <value>449, 12</value>
   </data>
   <data name="label12.TabIndex" type="System.Int32, mscorlib">
     <value>34</value>
@@ -711,7 +711,7 @@ Hiding an overlay only turns it invisible. It still runs in the background and c
     <value>3, 3, 3, 3</value>
   </data>
   <data name="tabGeneral.Size" type="System.Drawing.Size, System.Drawing">
-    <value>610, 558</value>
+    <value>610, 513</value>
   </data>
   <data name="tabGeneral.TabIndex" type="System.Int32, mscorlib">
     <value>0</value>
@@ -732,10 +732,10 @@ Hiding an overlay only turns it invisible. It still runs in the background and c
     <value>0</value>
   </data>
   <data name="btnApplyHotkeyChanges.Location" type="System.Drawing.Point, System.Drawing">
-    <value>363, 7</value>
+    <value>363, 6</value>
   </data>
   <data name="btnApplyHotkeyChanges.Size" type="System.Drawing.Size, System.Drawing">
-    <value>125, 28</value>
+    <value>125, 26</value>
   </data>
   <data name="btnApplyHotkeyChanges.TabIndex" type="System.Int32, mscorlib">
     <value>3</value>
@@ -756,10 +756,10 @@ Hiding an overlay only turns it invisible. It still runs in the background and c
     <value>0</value>
   </data>
   <data name="btnRemoveHotkey.Location" type="System.Drawing.Point, System.Drawing">
-    <value>164, 7</value>
+    <value>164, 6</value>
   </data>
   <data name="btnRemoveHotkey.Size" type="System.Drawing.Size, System.Drawing">
-    <value>180, 28</value>
+    <value>180, 26</value>
   </data>
   <data name="btnRemoveHotkey.TabIndex" type="System.Int32, mscorlib">
     <value>2</value>
@@ -780,10 +780,10 @@ Hiding an overlay only turns it invisible. It still runs in the background and c
     <value>1</value>
   </data>
   <data name="btnAddHotkey.Location" type="System.Drawing.Point, System.Drawing">
-    <value>7, 7</value>
+    <value>7, 6</value>
   </data>
   <data name="btnAddHotkey.Size" type="System.Drawing.Size, System.Drawing">
-    <value>139, 28</value>
+    <value>139, 26</value>
   </data>
   <data name="btnAddHotkey.TabIndex" type="System.Int32, mscorlib">
     <value>1</value>
@@ -843,10 +843,10 @@ Hiding an overlay only turns it invisible. It still runs in the background and c
     <value>150</value>
   </data>
   <data name="hotkeyGridView.Location" type="System.Drawing.Point, System.Drawing">
-    <value>6, 41</value>
+    <value>6, 38</value>
   </data>
   <data name="hotkeyGridView.Size" type="System.Drawing.Size, System.Drawing">
-    <value>595, 511</value>
+    <value>595, 472</value>
   </data>
   <data name="hotkeyGridView.TabIndex" type="System.Int32, mscorlib">
     <value>0</value>
@@ -870,7 +870,7 @@ Hiding an overlay only turns it invisible. It still runs in the background and c
     <value>3, 3, 3, 3</value>
   </data>
   <data name="tabHotkeys.Size" type="System.Drawing.Size, System.Drawing">
-    <value>610, 558</value>
+    <value>610, 513</value>
   </data>
   <data name="tabHotkeys.TabIndex" type="System.Int32, mscorlib">
     <value>1</value>
@@ -900,10 +900,10 @@ Hiding an overlay only turns it invisible. It still runs in the background and c
     <value>NoControl</value>
   </data>
   <data name="label15.Location" type="System.Drawing.Point, System.Drawing">
-    <value>4, 62</value>
+    <value>4, 57</value>
   </data>
   <data name="label15.Size" type="System.Drawing.Size, System.Drawing">
-    <value>34, 13</value>
+    <value>29, 12</value>
   </data>
   <data name="label15.TabIndex" type="System.Int32, mscorlib">
     <value>37</value>
@@ -945,7 +945,7 @@ Hiding an overlay only turns it invisible. It still runs in the background and c
     <value>3, 3</value>
   </data>
   <data name="tbZoom.Size" type="System.Drawing.Size, System.Drawing">
-    <value>332, 27</value>
+    <value>332, 24</value>
   </data>
   <data name="tbZoom.TabIndex" type="System.Int32, mscorlib">
     <value>40</value>
@@ -972,7 +972,7 @@ Hiding an overlay only turns it invisible. It still runs in the background and c
     <value>341, 3</value>
   </data>
   <data name="btnResetZoom.Size" type="System.Drawing.Size, System.Drawing">
-    <value>88, 27</value>
+    <value>88, 24</value>
   </data>
   <data name="btnResetZoom.TabIndex" type="System.Int32, mscorlib">
     <value>41</value>
@@ -993,13 +993,13 @@ Hiding an overlay only turns it invisible. It still runs in the background and c
     <value>1</value>
   </data>
   <data name="tableLayoutPanel4.Location" type="System.Drawing.Point, System.Drawing">
-    <value>160, 59</value>
+    <value>160, 54</value>
   </data>
   <data name="tableLayoutPanel4.RowCount" type="System.Int32, mscorlib">
     <value>1</value>
   </data>
   <data name="tableLayoutPanel4.Size" type="System.Drawing.Size, System.Drawing">
-    <value>432, 33</value>
+    <value>432, 30</value>
   </data>
   <data name="tableLayoutPanel4.TabIndex" type="System.Int32, mscorlib">
     <value>42</value>
@@ -1026,10 +1026,10 @@ Hiding an overlay only turns it invisible. It still runs in the background and c
     <value>NoControl</value>
   </data>
   <data name="checkLogConsoleMessages.Location" type="System.Drawing.Point, System.Drawing">
-    <value>160, 36</value>
+    <value>160, 33</value>
   </data>
   <data name="checkLogConsoleMessages.Size" type="System.Drawing.Size, System.Drawing">
-    <value>305, 17</value>
+    <value>372, 16</value>
   </data>
   <data name="checkLogConsoleMessages.TabIndex" type="System.Int32, mscorlib">
     <value>40</value>
@@ -1056,10 +1056,10 @@ Hiding an overlay only turns it invisible. It still runs in the background and c
     <value>NoControl</value>
   </data>
   <data name="label6.Location" type="System.Drawing.Point, System.Drawing">
-    <value>4, 11</value>
+    <value>4, 10</value>
   </data>
   <data name="label6.Size" type="System.Drawing.Size, System.Drawing">
-    <value>77, 13</value>
+    <value>89, 12</value>
   </data>
   <data name="label6.TabIndex" type="System.Int32, mscorlib">
     <value>12</value>
@@ -1083,13 +1083,13 @@ Hiding an overlay only turns it invisible. It still runs in the background and c
     <value>3</value>
   </data>
   <data name="nudMaxFrameRate.Location" type="System.Drawing.Point, System.Drawing">
-    <value>160, 12</value>
+    <value>160, 11</value>
   </data>
   <data name="nudMaxFrameRate.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
     <value>1, 1, 1, 1</value>
   </data>
   <data name="nudMaxFrameRate.Size" type="System.Drawing.Size, System.Drawing">
-    <value>432, 20</value>
+    <value>432, 21</value>
   </data>
   <data name="nudMaxFrameRate.TabIndex" type="System.Int32, mscorlib">
     <value>13</value>
@@ -1110,7 +1110,7 @@ Hiding an overlay only turns it invisible. It still runs in the background and c
     <value>4, 22</value>
   </data>
   <data name="tabAdvanced.Size" type="System.Drawing.Size, System.Drawing">
-    <value>610, 558</value>
+    <value>610, 513</value>
   </data>
   <data name="tabAdvanced.TabIndex" type="System.Int32, mscorlib">
     <value>2</value>
@@ -1140,10 +1140,10 @@ Hiding an overlay only turns it invisible. It still runs in the background and c
     <value>NoControl</value>
   </data>
   <data name="label5.Location" type="System.Drawing.Point, System.Drawing">
-    <value>3, 10</value>
+    <value>3, 9</value>
   </data>
   <data name="label5.Size" type="System.Drawing.Size, System.Drawing">
-    <value>105, 13</value>
+    <value>113, 12</value>
   </data>
   <data name="label5.TabIndex" type="System.Int32, mscorlib">
     <value>30</value>
@@ -1173,10 +1173,10 @@ Hiding an overlay only turns it invisible. It still runs in the background and c
     <value>NoControl</value>
   </data>
   <data name="checkActwsCompatbility.Location" type="System.Drawing.Point, System.Drawing">
-    <value>155, 10</value>
+    <value>155, 9</value>
   </data>
   <data name="checkActwsCompatbility.Size" type="System.Drawing.Size, System.Drawing">
-    <value>250, 17</value>
+    <value>294, 16</value>
   </data>
   <data name="checkActwsCompatbility.TabIndex" type="System.Int32, mscorlib">
     <value>28</value>
@@ -1203,10 +1203,10 @@ Hiding an overlay only turns it invisible. It still runs in the background and c
     <value>NoControl</value>
   </data>
   <data name="label11.Location" type="System.Drawing.Point, System.Drawing">
-    <value>152, 30</value>
+    <value>152, 28</value>
   </data>
   <data name="label11.Size" type="System.Drawing.Size, System.Drawing">
-    <value>436, 35</value>
+    <value>436, 32</value>
   </data>
   <data name="label11.TabIndex" type="System.Int32, mscorlib">
     <value>31</value>
@@ -1233,10 +1233,10 @@ Hiding an overlay only turns it invisible. It still runs in the background and c
     <value>NoControl</value>
   </data>
   <data name="checkNoFocus.Location" type="System.Drawing.Point, System.Drawing">
-    <value>155, 68</value>
+    <value>155, 63</value>
   </data>
   <data name="checkNoFocus.Size" type="System.Drawing.Size, System.Drawing">
-    <value>187, 17</value>
+    <value>234, 16</value>
   </data>
   <data name="checkNoFocus.TabIndex" type="System.Int32, mscorlib">
     <value>38</value>
@@ -1263,10 +1263,10 @@ Hiding an overlay only turns it invisible. It still runs in the background and c
     <value>NoControl</value>
   </data>
   <data name="lblNoFocus.Location" type="System.Drawing.Point, System.Drawing">
-    <value>3, 69</value>
+    <value>3, 64</value>
   </data>
   <data name="lblNoFocus.Size" type="System.Drawing.Size, System.Drawing">
-    <value>53, 13</value>
+    <value>53, 12</value>
   </data>
   <data name="lblNoFocus.TabIndex" type="System.Int32, mscorlib">
     <value>35</value>
@@ -1293,7 +1293,7 @@ Hiding an overlay only turns it invisible. It still runs in the background and c
     <value>4, 22</value>
   </data>
   <data name="tabACTWS.Size" type="System.Drawing.Size, System.Drawing">
-    <value>610, 558</value>
+    <value>610, 513</value>
   </data>
   <data name="tabACTWS.TabIndex" type="System.Int32, mscorlib">
     <value>3</value>
@@ -1317,7 +1317,7 @@ Hiding an overlay only turns it invisible. It still runs in the background and c
     <value>0, 3</value>
   </data>
   <data name="tabControl1.Size" type="System.Drawing.Size, System.Drawing">
-    <value>618, 584</value>
+    <value>618, 539</value>
   </data>
   <data name="tabControl1.TabIndex" type="System.Int32, mscorlib">
     <value>42</value>
@@ -1350,7 +1350,7 @@ Hiding an overlay only turns it invisible. It still runs in the background and c
     <value>3, 3</value>
   </data>
   <data name="buttonMiniParseOpenDevTools.Size" type="System.Drawing.Size, System.Drawing">
-    <value>182, 37</value>
+    <value>182, 34</value>
   </data>
   <data name="buttonMiniParseOpenDevTools.TabIndex" type="System.Int32, mscorlib">
     <value>2</value>
@@ -1380,7 +1380,7 @@ Hiding an overlay only turns it invisible. It still runs in the background and c
     <value>191, 3</value>
   </data>
   <data name="buttonMiniParseReloadBrowser.Size" type="System.Drawing.Size, System.Drawing">
-    <value>182, 37</value>
+    <value>182, 34</value>
   </data>
   <data name="buttonMiniParseReloadBrowser.TabIndex" type="System.Int32, mscorlib">
     <value>0</value>
@@ -1410,7 +1410,7 @@ Hiding an overlay only turns it invisible. It still runs in the background and c
     <value>379, 3</value>
   </data>
   <data name="buttonResetOverlayPosition.Size" type="System.Drawing.Size, System.Drawing">
-    <value>233, 37</value>
+    <value>233, 34</value>
   </data>
   <data name="buttonResetOverlayPosition.TabIndex" type="System.Int32, mscorlib">
     <value>3</value>
@@ -1431,13 +1431,13 @@ Hiding an overlay only turns it invisible. It still runs in the background and c
     <value>2</value>
   </data>
   <data name="tableLayoutPanel3.Location" type="System.Drawing.Point, System.Drawing">
-    <value>3, 593</value>
+    <value>3, 547</value>
   </data>
   <data name="tableLayoutPanel3.RowCount" type="System.Int32, mscorlib">
     <value>1</value>
   </data>
   <data name="tableLayoutPanel3.Size" type="System.Drawing.Size, System.Drawing">
-    <value>615, 43</value>
+    <value>615, 40</value>
   </data>
   <data name="tableLayoutPanel3.TabIndex" type="System.Int32, mscorlib">
     <value>0</value>
@@ -1461,10 +1461,10 @@ Hiding an overlay only turns it invisible. It still runs in the background and c
     <value>True</value>
   </metadata>
   <data name="$this.AutoScaleDimensions" type="System.Drawing.SizeF, System.Drawing">
-    <value>6, 13</value>
+    <value>6, 12</value>
   </data>
   <data name="$this.Size" type="System.Drawing.Size, System.Drawing">
-    <value>646, 655</value>
+    <value>646, 605</value>
   </data>
   <data name="&gt;&gt;hotkeyColEnabled.Name" xml:space="preserve">
     <value>hotkeyColEnabled</value>

--- a/OverlayPlugin.Core/Overlays/MiniParseConfigPanel.zh-CN.resx
+++ b/OverlayPlugin.Core/Overlays/MiniParseConfigPanel.zh-CN.resx
@@ -118,11 +118,17 @@
     <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
   <assembly alias="System.Drawing" name="System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a" />
+  <data name="applyPresetCombo.Location" type="System.Drawing.Point, System.Drawing">
+    <value>180, 228</value>
+  </data>
   <data name="cbMuteHidden.Location" type="System.Drawing.Point, System.Drawing">
-    <value>178, 270</value>
+    <value>177, 303</value>
+  </data>
+  <data name="label13.Location" type="System.Drawing.Point, System.Drawing">
+    <value>6, 305</value>
   </data>
   <data name="label13.Size" type="System.Drawing.Size, System.Drawing">
-    <value>115, 13</value>
+    <value>113, 12</value>
   </data>
   <data name="label13.Text" xml:space="preserve">
     <value>隐藏时使悬浮窗静音</value>
@@ -151,14 +157,17 @@
   <data name="cbEnableOverlay.Location" type="System.Drawing.Point, System.Drawing">
     <value>178, 25</value>
   </data>
+  <data name="label7.Location" type="System.Drawing.Point, System.Drawing">
+    <value>6, 27</value>
+  </data>
   <data name="label7.Size" type="System.Drawing.Size, System.Drawing">
-    <value>67, 13</value>
+    <value>65, 12</value>
   </data>
   <data name="label7.Text" xml:space="preserve">
     <value>启用悬浮窗</value>
   </data>
   <data name="textMiniParseUrl.Size" type="System.Drawing.Size, System.Drawing">
-    <value>370, 20</value>
+    <value>370, 21</value>
   </data>
   <data name="buttonMiniParseSelectFile.Location" type="System.Drawing.Point, System.Drawing">
     <value>370, 0</value>
@@ -167,19 +176,22 @@
     <value>浏览</value>
   </data>
   <data name="tableLayoutPanel2.Location" type="System.Drawing.Point, System.Drawing">
-    <value>178, 184</value>
+    <value>180, 200</value>
   </data>
   <data name="tableLayoutPanel2.Size" type="System.Drawing.Size, System.Drawing">
     <value>407, 24</value>
   </data>
+  <data name="label1.Location" type="System.Drawing.Point, System.Drawing">
+    <value>6, 203</value>
+  </data>
   <data name="label1.Size" type="System.Drawing.Size, System.Drawing">
-    <value>67, 13</value>
+    <value>65, 12</value>
   </data>
   <data name="label1.Text" xml:space="preserve">
     <value>悬浮窗路径</value>
   </data>
   <data name="label3.Size" type="System.Drawing.Size, System.Drawing">
-    <value>67, 13</value>
+    <value>65, 12</value>
   </data>
   <data name="label3.Text" xml:space="preserve">
     <value>显示悬浮窗</value>
@@ -190,14 +202,20 @@
   <data name="checkMiniParseVisible.Location" type="System.Drawing.Point, System.Drawing">
     <value>178, 3</value>
   </data>
+  <data name="label9.Location" type="System.Drawing.Point, System.Drawing">
+    <value>6, 128</value>
+  </data>
   <data name="label9.Size" type="System.Drawing.Size, System.Drawing">
-    <value>67, 13</value>
+    <value>65, 12</value>
   </data>
   <data name="label9.Text" xml:space="preserve">
     <value>锁定悬浮窗</value>
   </data>
+  <data name="label2.Location" type="System.Drawing.Point, System.Drawing">
+    <value>6, 106</value>
+  </data>
   <data name="label2.Size" type="System.Drawing.Size, System.Drawing">
-    <value>55, 13</value>
+    <value>53, 12</value>
   </data>
   <data name="label2.Text" xml:space="preserve">
     <value>鼠标穿透</value>
@@ -205,20 +223,23 @@
   <data name="checkMiniParseClickthru.Location" type="System.Drawing.Point, System.Drawing">
     <value>178, 104</value>
   </data>
+  <data name="label4.Location" type="System.Drawing.Point, System.Drawing">
+    <value>6, 260</value>
+  </data>
   <data name="label4.Size" type="System.Drawing.Size, System.Drawing">
-    <value>160, 13</value>
+    <value>161, 12</value>
   </data>
   <data name="label4.Text" xml:space="preserve">
     <value>在悬浮窗下强制启用白色背景</value>
   </data>
   <data name="cbWhiteBg.Location" type="System.Drawing.Point, System.Drawing">
-    <value>178, 212</value>
+    <value>180, 260</value>
   </data>
   <data name="label12.Location" type="System.Drawing.Point, System.Drawing">
-    <value>175, 229</value>
+    <value>175, 277</value>
   </data>
   <data name="label12.Size" type="System.Drawing.Size, System.Drawing">
-    <value>383, 13</value>
+    <value>389, 12</value>
   </data>
   <data name="label12.Text" xml:space="preserve">
     <value>如果您找不到悬浮窗或由于某种原因无法调整其大小时，请启用此选项。</value>
@@ -254,9 +275,6 @@
   <data name="tabHotkeys.Text" xml:space="preserve">
     <value>快捷键</value>
   </data>
-  <data name="label15.Size" type="System.Drawing.Size, System.Drawing">
-    <value>31, 13</value>
-  </data>
   <data name="label15.Text" xml:space="preserve">
     <value>缩放</value>
   </data>
@@ -264,13 +282,13 @@
     <value>重设</value>
   </data>
   <data name="checkLogConsoleMessages.Size" type="System.Drawing.Size, System.Drawing">
-    <value>242, 17</value>
+    <value>240, 16</value>
   </data>
   <data name="checkLogConsoleMessages.Text" xml:space="preserve">
     <value>在日志中显示来自此悬浮窗的控制台消息</value>
   </data>
   <data name="label6.Size" type="System.Drawing.Size, System.Drawing">
-    <value>67, 13</value>
+    <value>65, 12</value>
   </data>
   <data name="label6.Text" xml:space="preserve">
     <value>最大帧速率</value>
@@ -279,13 +297,13 @@
     <value>高级</value>
   </data>
   <data name="label5.Size" type="System.Drawing.Size, System.Drawing">
-    <value>82, 13</value>
+    <value>71, 12</value>
   </data>
   <data name="label5.Text" xml:space="preserve">
     <value>ACTWS兼容性</value>
   </data>
   <data name="checkActwsCompatbility.Size" type="System.Drawing.Size, System.Drawing">
-    <value>200, 17</value>
+    <value>192, 16</value>
   </data>
   <data name="checkActwsCompatbility.Text" xml:space="preserve">
     <value>此悬浮窗需要使用ACTWebSocket</value>
@@ -294,13 +312,10 @@
     <value>仅当悬浮窗与OverlayPlugin不兼容时，才需要启用此选项。</value>
   </data>
   <data name="checkNoFocus.Size" type="System.Drawing.Size, System.Drawing">
-    <value>110, 17</value>
+    <value>108, 16</value>
   </data>
   <data name="checkNoFocus.Text" xml:space="preserve">
     <value>不焦点此悬浮窗</value>
-  </data>
-  <data name="lblNoFocus.Size" type="System.Drawing.Size, System.Drawing">
-    <value>55, 13</value>
   </data>
   <data name="lblNoFocus.Text" xml:space="preserve">
     <value>取消焦点</value>
@@ -313,8 +328,5 @@
   </data>
   <data name="buttonResetOverlayPosition.Text" xml:space="preserve">
     <value>重置悬浮窗位置</value>
-  </data>
-  <data name="tabACTWS.Text" xml:space="preserve">
-    <value>ACTWS</value>
   </data>
 </root>


### PR DESCRIPTION
Recently the built-in overlay config panel has changed a lot, and the Chinese layout has some issues which caused layout problems, such as label is not aligned with checkbox, misplaced new dropdowns, etc.

This PR will fix Chinese problems and make the built-in config panel label aligned correctly.