### PR TITLE
Add options for ending encounters after wipes and out of game combat

### DIFF
--- a/OverlayPlugin.Core/EventSources/BuiltinEventConfig.cs
+++ b/OverlayPlugin.Core/EventSources/BuiltinEventConfig.cs
@@ -12,6 +12,8 @@ namespace RainbowMage.OverlayPlugin.EventSources
         public event EventHandler SortKeyChanged;
         public event EventHandler SortDescChanged;
         public event EventHandler UpdateDpsDuringImportChanged;
+        public event EventHandler EndEncounterAfterWipeChanged;
+        public event EventHandler EndEncounterOutOfCombatChanged;
 
         private int updateInterval;
         public int UpdateInterval {
@@ -97,6 +99,40 @@ namespace RainbowMage.OverlayPlugin.EventSources
             }
         }
 
+        private bool endEncounterAfterWipe;
+        public bool EndEncounterAfterWipe
+        {
+            get
+            {
+                return this.endEncounterAfterWipe;
+            }
+            set
+            {
+                if (this.endEncounterAfterWipe != value)
+                {
+                    this.endEncounterAfterWipe = value;
+                    EndEncounterAfterWipeChanged?.Invoke(this, new EventArgs());
+                }
+            }
+        }
+
+        private bool endEncounterOutOfCombat;
+        public bool EndEncounterOutOfCombat
+        {
+            get
+            {
+                return this.endEncounterOutOfCombat;
+            }
+            set
+            {
+                if (this.endEncounterOutOfCombat != value)
+                {
+                    this.endEncounterOutOfCombat = value;
+                    EndEncounterOutOfCombatChanged?.Invoke(this, new EventArgs());
+                }
+            }
+        }
+
         // Data that overlays can save/load via event handlers.
         public Dictionary<string, JToken> OverlayData = new Dictionary<string, JToken>();
 
@@ -107,6 +143,8 @@ namespace RainbowMage.OverlayPlugin.EventSources
             this.sortKey = "encdps";
             this.sortDesc = true;
             this.updateDpsDuringImport = false;
+            this.endEncounterAfterWipe = false;
+            this.endEncounterOutOfCombat = false;
         }
 
         public static BuiltinEventConfig LoadConfig(IPluginConfig Config)
@@ -140,6 +178,16 @@ namespace RainbowMage.OverlayPlugin.EventSources
                 if (obj.TryGetValue("UpdateDpsDuringImport", out value))
                 {
                     result.updateDpsDuringImport = value.ToObject<bool>();
+                }
+
+                if (obj.TryGetValue("EndEncounterAfterWipe", out value))
+                {
+                    result.endEncounterAfterWipe = value.ToObject<bool>();
+                }
+
+                if (obj.TryGetValue("EndEncounterOutOfCombat", out value))
+                {
+                    result.endEncounterOutOfCombat = value.ToObject<bool>();
                 }
 
                 if (obj.TryGetValue("OverlayData", out value))

--- a/OverlayPlugin.Core/EventSources/BuiltinEventConfigPanel.Designer.cs
+++ b/OverlayPlugin.Core/EventSources/BuiltinEventConfigPanel.Designer.cs
@@ -31,6 +31,10 @@
         {
             System.ComponentModel.ComponentResourceManager resources = new System.ComponentModel.ComponentResourceManager(typeof(BuiltinEventConfigPanel));
             this.tableLayoutPanel1 = new System.Windows.Forms.TableLayoutPanel();
+            this.cbEndEncounterOutOfCombat = new System.Windows.Forms.CheckBox();
+            this.cbEndEncounterAfterWipe = new System.Windows.Forms.CheckBox();
+            this.label7 = new System.Windows.Forms.Label();
+            this.label6 = new System.Windows.Forms.Label();
             this.textEnmityInterval = new System.Windows.Forms.TextBox();
             this.label5 = new System.Windows.Forms.Label();
             this.comboSortKey = new System.Windows.Forms.ComboBox();
@@ -47,6 +51,10 @@
             // tableLayoutPanel1
             // 
             resources.ApplyResources(this.tableLayoutPanel1, "tableLayoutPanel1");
+            this.tableLayoutPanel1.Controls.Add(this.cbEndEncounterOutOfCombat, 1, 6);
+            this.tableLayoutPanel1.Controls.Add(this.cbEndEncounterAfterWipe, 1, 5);
+            this.tableLayoutPanel1.Controls.Add(this.label7, 0, 6);
+            this.tableLayoutPanel1.Controls.Add(this.label6, 0, 5);
             this.tableLayoutPanel1.Controls.Add(this.textEnmityInterval, 1, 4);
             this.tableLayoutPanel1.Controls.Add(this.label5, 0, 4);
             this.tableLayoutPanel1.Controls.Add(this.comboSortKey, 1, 1);
@@ -58,6 +66,30 @@
             this.tableLayoutPanel1.Controls.Add(this.label4, 0, 3);
             this.tableLayoutPanel1.Controls.Add(this.cbUpdateDuringImport, 1, 3);
             this.tableLayoutPanel1.Name = "tableLayoutPanel1";
+            // 
+            // cbEndEncounterOutOfCombat
+            // 
+            resources.ApplyResources(this.cbEndEncounterOutOfCombat, "cbEndEncounterOutOfCombat");
+            this.cbEndEncounterOutOfCombat.Name = "cbEndEncounterOutOfCombat";
+            this.cbEndEncounterOutOfCombat.UseVisualStyleBackColor = true;
+            this.cbEndEncounterOutOfCombat.CheckedChanged += new System.EventHandler(this.cbEndEncounterOutOfCombat_CheckedChanged);
+            // 
+            // cbEndEncounterAfterWipe
+            // 
+            resources.ApplyResources(this.cbEndEncounterAfterWipe, "cbEndEncounterAfterWipe");
+            this.cbEndEncounterAfterWipe.Name = "cbEndEncounterAfterWipe";
+            this.cbEndEncounterAfterWipe.UseVisualStyleBackColor = true;
+            this.cbEndEncounterAfterWipe.CheckedChanged += new System.EventHandler(this.cbEndEncounterAfterWipe_CheckedChanged);
+            // 
+            // label7
+            // 
+            resources.ApplyResources(this.label7, "label7");
+            this.label7.Name = "label7";
+            // 
+            // label6
+            // 
+            resources.ApplyResources(this.label6, "label6");
+            this.label6.Name = "label6";
             // 
             // textEnmityInterval
             // 
@@ -143,5 +175,9 @@
         private System.Windows.Forms.CheckBox cbUpdateDuringImport;
         private System.Windows.Forms.TextBox textEnmityInterval;
         private System.Windows.Forms.Label label5;
-    }
+        private System.Windows.Forms.CheckBox cbEndEncounterOutOfCombat;
+        private System.Windows.Forms.CheckBox cbEndEncounterAfterWipe;
+        private System.Windows.Forms.Label label7;
+        private System.Windows.Forms.Label label6;
+  }
 }

--- a/OverlayPlugin.Core/EventSources/BuiltinEventConfigPanel.cs
+++ b/OverlayPlugin.Core/EventSources/BuiltinEventConfigPanel.cs
@@ -49,6 +49,9 @@ namespace RainbowMage.OverlayPlugin.EventSources
 
             this.checkSortDesc.Checked = config.SortDesc;
             this.cbUpdateDuringImport.Checked = config.UpdateDpsDuringImport;
+
+            this.cbEndEncounterAfterWipe.Checked = config.EndEncounterAfterWipe;
+            this.cbEndEncounterOutOfCombat.Checked = config.EndEncounterOutOfCombat;
         }
 
         private void SetupConfigEventHandlers()
@@ -92,6 +95,22 @@ namespace RainbowMage.OverlayPlugin.EventSources
                     this.cbUpdateDuringImport.Checked = config.UpdateDpsDuringImport;
                 });
             };
+
+            this.config.EndEncounterAfterWipeChanged += (o, e) =>
+            {
+                this.InvokeIfRequired(() =>
+                {
+                    this.cbEndEncounterAfterWipe.Checked = config.EndEncounterAfterWipe;
+                });
+            };
+
+            this.config.EndEncounterOutOfCombatChanged += (o, e) =>
+            {
+                this.InvokeIfRequired(() =>
+                {
+                    this.cbEndEncounterOutOfCombat.Checked = config.EndEncounterOutOfCombat;
+                });
+            };
         }
 
         private void InvokeIfRequired(Action action)
@@ -131,6 +150,16 @@ namespace RainbowMage.OverlayPlugin.EventSources
         private void cbUpdateDuringImport_CheckedChanged(object sender, EventArgs e)
         {
             this.config.UpdateDpsDuringImport = this.cbUpdateDuringImport.Checked;
+        }
+
+        private void cbEndEncounterAfterWipe_CheckedChanged(object sender, EventArgs e)
+        {
+            this.config.EndEncounterAfterWipe = this.cbEndEncounterAfterWipe.Checked;
+        }
+
+        private void cbEndEncounterOutOfCombat_CheckedChanged(object sender, EventArgs e)
+        {
+            this.config.EndEncounterOutOfCombat = this.cbEndEncounterOutOfCombat.Checked;
         }
 
         private void TextEnmityInterval_Leave(object sender, EventArgs e)

--- a/OverlayPlugin.Core/EventSources/BuiltinEventConfigPanel.resx
+++ b/OverlayPlugin.Core/EventSources/BuiltinEventConfigPanel.resx
@@ -121,16 +121,148 @@
   <data name="tableLayoutPanel1.ColumnCount" type="System.Int32, mscorlib">
     <value>2</value>
   </data>
+  <data name="cbEndEncounterOutOfCombat.AutoSize" type="System.Boolean, mscorlib">
+    <value>True</value>
+  </data>
   <assembly alias="System.Windows.Forms" name="System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089" />
+  <data name="cbEndEncounterOutOfCombat.Dock" type="System.Windows.Forms.DockStyle, System.Windows.Forms">
+    <value>Fill</value>
+  </data>
+  <data name="cbEndEncounterOutOfCombat.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
+    <value>NoControl</value>
+  </data>
+  <assembly alias="System.Drawing" name="System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a" />
+  <data name="cbEndEncounterOutOfCombat.Location" type="System.Drawing.Point, System.Drawing">
+    <value>208, 153</value>
+  </data>
+  <data name="cbEndEncounterOutOfCombat.Size" type="System.Drawing.Size, System.Drawing">
+    <value>440, 14</value>
+  </data>
+  <data name="cbEndEncounterOutOfCombat.TabIndex" type="System.Int32, mscorlib">
+    <value>18</value>
+  </data>
+  <data name="&gt;&gt;cbEndEncounterOutOfCombat.Name" xml:space="preserve">
+    <value>cbEndEncounterOutOfCombat</value>
+  </data>
+  <data name="&gt;&gt;cbEndEncounterOutOfCombat.Type" xml:space="preserve">
+    <value>System.Windows.Forms.CheckBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;cbEndEncounterOutOfCombat.Parent" xml:space="preserve">
+    <value>tableLayoutPanel1</value>
+  </data>
+  <data name="&gt;&gt;cbEndEncounterOutOfCombat.ZOrder" xml:space="preserve">
+    <value>0</value>
+  </data>
+  <data name="cbEndEncounterAfterWipe.AutoSize" type="System.Boolean, mscorlib">
+    <value>True</value>
+  </data>
+  <data name="cbEndEncounterAfterWipe.Dock" type="System.Windows.Forms.DockStyle, System.Windows.Forms">
+    <value>Fill</value>
+  </data>
+  <data name="cbEndEncounterAfterWipe.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
+    <value>NoControl</value>
+  </data>
+  <data name="cbEndEncounterAfterWipe.Location" type="System.Drawing.Point, System.Drawing">
+    <value>208, 133</value>
+  </data>
+  <data name="cbEndEncounterAfterWipe.Size" type="System.Drawing.Size, System.Drawing">
+    <value>440, 14</value>
+  </data>
+  <data name="cbEndEncounterAfterWipe.TabIndex" type="System.Int32, mscorlib">
+    <value>17</value>
+  </data>
+  <data name="&gt;&gt;cbEndEncounterAfterWipe.Name" xml:space="preserve">
+    <value>cbEndEncounterAfterWipe</value>
+  </data>
+  <data name="&gt;&gt;cbEndEncounterAfterWipe.Type" xml:space="preserve">
+    <value>System.Windows.Forms.CheckBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;cbEndEncounterAfterWipe.Parent" xml:space="preserve">
+    <value>tableLayoutPanel1</value>
+  </data>
+  <data name="&gt;&gt;cbEndEncounterAfterWipe.ZOrder" xml:space="preserve">
+    <value>1</value>
+  </data>
+  <data name="label7.AutoSize" type="System.Boolean, mscorlib">
+    <value>True</value>
+  </data>
+  <data name="label7.Dock" type="System.Windows.Forms.DockStyle, System.Windows.Forms">
+    <value>Fill</value>
+  </data>
+  <data name="label7.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
+    <value>NoControl</value>
+  </data>
+  <data name="label7.Location" type="System.Drawing.Point, System.Drawing">
+    <value>3, 150</value>
+  </data>
+  <data name="label7.Size" type="System.Drawing.Size, System.Drawing">
+    <value>199, 20</value>
+  </data>
+  <data name="label7.TabIndex" type="System.Int32, mscorlib">
+    <value>16</value>
+  </data>
+  <data name="label7.Text" xml:space="preserve">
+    <value>End ACT encounter out of combat</value>
+  </data>
+  <data name="label7.TextAlign" type="System.Drawing.ContentAlignment, System.Drawing">
+    <value>MiddleLeft</value>
+  </data>
+  <data name="&gt;&gt;label7.Name" xml:space="preserve">
+    <value>label7</value>
+  </data>
+  <data name="&gt;&gt;label7.Type" xml:space="preserve">
+    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;label7.Parent" xml:space="preserve">
+    <value>tableLayoutPanel1</value>
+  </data>
+  <data name="&gt;&gt;label7.ZOrder" xml:space="preserve">
+    <value>2</value>
+  </data>
+  <data name="label6.AutoSize" type="System.Boolean, mscorlib">
+    <value>True</value>
+  </data>
+  <data name="label6.Dock" type="System.Windows.Forms.DockStyle, System.Windows.Forms">
+    <value>Fill</value>
+  </data>
+  <data name="label6.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
+    <value>NoControl</value>
+  </data>
+  <data name="label6.Location" type="System.Drawing.Point, System.Drawing">
+    <value>3, 130</value>
+  </data>
+  <data name="label6.Size" type="System.Drawing.Size, System.Drawing">
+    <value>199, 20</value>
+  </data>
+  <data name="label6.TabIndex" type="System.Int32, mscorlib">
+    <value>15</value>
+  </data>
+  <data name="label6.Text" xml:space="preserve">
+    <value>End ACT encounter after wipe</value>
+  </data>
+  <data name="label6.TextAlign" type="System.Drawing.ContentAlignment, System.Drawing">
+    <value>MiddleLeft</value>
+  </data>
+  <data name="&gt;&gt;label6.Name" xml:space="preserve">
+    <value>label6</value>
+  </data>
+  <data name="&gt;&gt;label6.Type" xml:space="preserve">
+    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;label6.Parent" xml:space="preserve">
+    <value>tableLayoutPanel1</value>
+  </data>
+  <data name="&gt;&gt;label6.ZOrder" xml:space="preserve">
+    <value>3</value>
+  </data>
   <data name="textEnmityInterval.Dock" type="System.Windows.Forms.DockStyle, System.Windows.Forms">
     <value>Fill</value>
   </data>
-  <assembly alias="System.Drawing" name="System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a" />
   <data name="textEnmityInterval.Location" type="System.Drawing.Point, System.Drawing">
-    <value>158, 107</value>
+    <value>208, 107</value>
   </data>
   <data name="textEnmityInterval.Size" type="System.Drawing.Size, System.Drawing">
-    <value>490, 20</value>
+    <value>440, 20</value>
   </data>
   <data name="textEnmityInterval.TabIndex" type="System.Int32, mscorlib">
     <value>14</value>
@@ -145,7 +277,7 @@
     <value>tableLayoutPanel1</value>
   </data>
   <data name="&gt;&gt;textEnmityInterval.ZOrder" xml:space="preserve">
-    <value>0</value>
+    <value>4</value>
   </data>
   <data name="label5.AutoSize" type="System.Boolean, mscorlib">
     <value>True</value>
@@ -160,7 +292,7 @@
     <value>3, 104</value>
   </data>
   <data name="label5.Size" type="System.Drawing.Size, System.Drawing">
-    <value>149, 26</value>
+    <value>199, 26</value>
   </data>
   <data name="label5.TabIndex" type="System.Int32, mscorlib">
     <value>13</value>
@@ -181,16 +313,16 @@
     <value>tableLayoutPanel1</value>
   </data>
   <data name="&gt;&gt;label5.ZOrder" xml:space="preserve">
-    <value>1</value>
+    <value>5</value>
   </data>
   <data name="comboSortKey.Dock" type="System.Windows.Forms.DockStyle, System.Windows.Forms">
     <value>Fill</value>
   </data>
   <data name="comboSortKey.Location" type="System.Drawing.Point, System.Drawing">
-    <value>158, 29</value>
+    <value>208, 29</value>
   </data>
   <data name="comboSortKey.Size" type="System.Drawing.Size, System.Drawing">
-    <value>490, 21</value>
+    <value>440, 21</value>
   </data>
   <data name="comboSortKey.TabIndex" type="System.Int32, mscorlib">
     <value>5</value>
@@ -205,7 +337,7 @@
     <value>tableLayoutPanel1</value>
   </data>
   <data name="&gt;&gt;comboSortKey.ZOrder" xml:space="preserve">
-    <value>2</value>
+    <value>6</value>
   </data>
   <data name="label1.AutoSize" type="System.Boolean, mscorlib">
     <value>True</value>
@@ -217,7 +349,7 @@
     <value>3, 26</value>
   </data>
   <data name="label1.Size" type="System.Drawing.Size, System.Drawing">
-    <value>149, 26</value>
+    <value>199, 26</value>
   </data>
   <data name="label1.TabIndex" type="System.Int32, mscorlib">
     <value>6</value>
@@ -238,7 +370,7 @@
     <value>tableLayoutPanel1</value>
   </data>
   <data name="&gt;&gt;label1.ZOrder" xml:space="preserve">
-    <value>3</value>
+    <value>7</value>
   </data>
   <data name="label2.AutoSize" type="System.Boolean, mscorlib">
     <value>True</value>
@@ -250,7 +382,7 @@
     <value>3, 0</value>
   </data>
   <data name="label2.Size" type="System.Drawing.Size, System.Drawing">
-    <value>149, 26</value>
+    <value>199, 26</value>
   </data>
   <data name="label2.TabIndex" type="System.Int32, mscorlib">
     <value>7</value>
@@ -271,16 +403,16 @@
     <value>tableLayoutPanel1</value>
   </data>
   <data name="&gt;&gt;label2.ZOrder" xml:space="preserve">
-    <value>4</value>
+    <value>8</value>
   </data>
   <data name="textUpdateInterval.Dock" type="System.Windows.Forms.DockStyle, System.Windows.Forms">
     <value>Fill</value>
   </data>
   <data name="textUpdateInterval.Location" type="System.Drawing.Point, System.Drawing">
-    <value>158, 3</value>
+    <value>208, 3</value>
   </data>
   <data name="textUpdateInterval.Size" type="System.Drawing.Size, System.Drawing">
-    <value>490, 20</value>
+    <value>440, 20</value>
   </data>
   <data name="textUpdateInterval.TabIndex" type="System.Int32, mscorlib">
     <value>8</value>
@@ -295,7 +427,7 @@
     <value>tableLayoutPanel1</value>
   </data>
   <data name="&gt;&gt;textUpdateInterval.ZOrder" xml:space="preserve">
-    <value>5</value>
+    <value>9</value>
   </data>
   <data name="label3.AutoSize" type="System.Boolean, mscorlib">
     <value>True</value>
@@ -307,7 +439,7 @@
     <value>3, 52</value>
   </data>
   <data name="label3.Size" type="System.Drawing.Size, System.Drawing">
-    <value>149, 26</value>
+    <value>199, 26</value>
   </data>
   <data name="label3.TabIndex" type="System.Int32, mscorlib">
     <value>9</value>
@@ -328,7 +460,7 @@
     <value>tableLayoutPanel1</value>
   </data>
   <data name="&gt;&gt;label3.ZOrder" xml:space="preserve">
-    <value>6</value>
+    <value>10</value>
   </data>
   <data name="checkSortDesc.AutoSize" type="System.Boolean, mscorlib">
     <value>True</value>
@@ -337,10 +469,10 @@
     <value>Fill</value>
   </data>
   <data name="checkSortDesc.Location" type="System.Drawing.Point, System.Drawing">
-    <value>158, 55</value>
+    <value>208, 55</value>
   </data>
   <data name="checkSortDesc.Size" type="System.Drawing.Size, System.Drawing">
-    <value>490, 20</value>
+    <value>440, 20</value>
   </data>
   <data name="checkSortDesc.TabIndex" type="System.Int32, mscorlib">
     <value>10</value>
@@ -355,7 +487,7 @@
     <value>tableLayoutPanel1</value>
   </data>
   <data name="&gt;&gt;checkSortDesc.ZOrder" xml:space="preserve">
-    <value>7</value>
+    <value>11</value>
   </data>
   <data name="label4.AutoSize" type="System.Boolean, mscorlib">
     <value>True</value>
@@ -367,7 +499,7 @@
     <value>3, 78</value>
   </data>
   <data name="label4.Size" type="System.Drawing.Size, System.Drawing">
-    <value>149, 26</value>
+    <value>199, 26</value>
   </data>
   <data name="label4.TabIndex" type="System.Int32, mscorlib">
     <value>11</value>
@@ -388,7 +520,7 @@
     <value>tableLayoutPanel1</value>
   </data>
   <data name="&gt;&gt;label4.ZOrder" xml:space="preserve">
-    <value>8</value>
+    <value>12</value>
   </data>
   <data name="cbUpdateDuringImport.AutoSize" type="System.Boolean, mscorlib">
     <value>True</value>
@@ -397,10 +529,10 @@
     <value>Fill</value>
   </data>
   <data name="cbUpdateDuringImport.Location" type="System.Drawing.Point, System.Drawing">
-    <value>158, 81</value>
+    <value>208, 81</value>
   </data>
   <data name="cbUpdateDuringImport.Size" type="System.Drawing.Size, System.Drawing">
-    <value>490, 20</value>
+    <value>440, 20</value>
   </data>
   <data name="cbUpdateDuringImport.TabIndex" type="System.Int32, mscorlib">
     <value>12</value>
@@ -415,7 +547,7 @@
     <value>tableLayoutPanel1</value>
   </data>
   <data name="&gt;&gt;cbUpdateDuringImport.ZOrder" xml:space="preserve">
-    <value>9</value>
+    <value>13</value>
   </data>
   <data name="tableLayoutPanel1.Dock" type="System.Windows.Forms.DockStyle, System.Windows.Forms">
     <value>Fill</value>
@@ -424,7 +556,7 @@
     <value>0, 0</value>
   </data>
   <data name="tableLayoutPanel1.RowCount" type="System.Int32, mscorlib">
-    <value>6</value>
+    <value>8</value>
   </data>
   <data name="tableLayoutPanel1.Size" type="System.Drawing.Size, System.Drawing">
     <value>651, 388</value>
@@ -445,7 +577,7 @@
     <value>0</value>
   </data>
   <data name="tableLayoutPanel1.LayoutSettings" type="System.Windows.Forms.TableLayoutSettings, System.Windows.Forms">
-    <value>&lt;?xml version="1.0" encoding="utf-16"?&gt;&lt;TableLayoutSettings&gt;&lt;Controls&gt;&lt;Control Name="textEnmityInterval" Row="4" RowSpan="1" Column="1" ColumnSpan="1" /&gt;&lt;Control Name="label5" Row="4" RowSpan="1" Column="0" ColumnSpan="1" /&gt;&lt;Control Name="comboSortKey" Row="1" RowSpan="1" Column="1" ColumnSpan="1" /&gt;&lt;Control Name="label1" Row="1" RowSpan="1" Column="0" ColumnSpan="1" /&gt;&lt;Control Name="label2" Row="0" RowSpan="1" Column="0" ColumnSpan="1" /&gt;&lt;Control Name="textUpdateInterval" Row="0" RowSpan="1" Column="1" ColumnSpan="1" /&gt;&lt;Control Name="label3" Row="2" RowSpan="1" Column="0" ColumnSpan="1" /&gt;&lt;Control Name="checkSortDesc" Row="2" RowSpan="1" Column="1" ColumnSpan="1" /&gt;&lt;Control Name="label4" Row="3" RowSpan="1" Column="0" ColumnSpan="1" /&gt;&lt;Control Name="cbUpdateDuringImport" Row="3" RowSpan="1" Column="1" ColumnSpan="1" /&gt;&lt;/Controls&gt;&lt;Columns Styles="Absolute,155,Percent,100" /&gt;&lt;Rows Styles="Absolute,26,Absolute,26,Absolute,26,Absolute,26,Absolute,26,Absolute,20" /&gt;&lt;/TableLayoutSettings&gt;</value>
+    <value>&lt;?xml version="1.0" encoding="utf-16"?&gt;&lt;TableLayoutSettings&gt;&lt;Controls&gt;&lt;Control Name="cbEndEncounterOutOfCombat" Row="6" RowSpan="1" Column="1" ColumnSpan="1" /&gt;&lt;Control Name="cbEndEncounterAfterWipe" Row="5" RowSpan="1" Column="1" ColumnSpan="1" /&gt;&lt;Control Name="label7" Row="6" RowSpan="1" Column="0" ColumnSpan="1" /&gt;&lt;Control Name="label6" Row="5" RowSpan="1" Column="0" ColumnSpan="1" /&gt;&lt;Control Name="textEnmityInterval" Row="4" RowSpan="1" Column="1" ColumnSpan="1" /&gt;&lt;Control Name="label5" Row="4" RowSpan="1" Column="0" ColumnSpan="1" /&gt;&lt;Control Name="comboSortKey" Row="1" RowSpan="1" Column="1" ColumnSpan="1" /&gt;&lt;Control Name="label1" Row="1" RowSpan="1" Column="0" ColumnSpan="1" /&gt;&lt;Control Name="label2" Row="0" RowSpan="1" Column="0" ColumnSpan="1" /&gt;&lt;Control Name="textUpdateInterval" Row="0" RowSpan="1" Column="1" ColumnSpan="1" /&gt;&lt;Control Name="label3" Row="2" RowSpan="1" Column="0" ColumnSpan="1" /&gt;&lt;Control Name="checkSortDesc" Row="2" RowSpan="1" Column="1" ColumnSpan="1" /&gt;&lt;Control Name="label4" Row="3" RowSpan="1" Column="0" ColumnSpan="1" /&gt;&lt;Control Name="cbUpdateDuringImport" Row="3" RowSpan="1" Column="1" ColumnSpan="1" /&gt;&lt;/Controls&gt;&lt;Columns Styles="Absolute,205,Percent,100" /&gt;&lt;Rows Styles="Absolute,26,Absolute,26,Absolute,26,Absolute,26,Absolute,26,Absolute,20,Absolute,20,Absolute,20" /&gt;&lt;/TableLayoutSettings&gt;</value>
   </data>
   <metadata name="$this.Localizable" type="System.Boolean, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">
     <value>True</value>

--- a/OverlayPlugin.Core/EventSources/EnmityMemory52.cs
+++ b/OverlayPlugin.Core/EventSources/EnmityMemory52.cs
@@ -16,17 +16,21 @@ namespace RainbowMage.OverlayPlugin.EventSources
         private IntPtr targetAddress = IntPtr.Zero;
         private IntPtr enmityAddress = IntPtr.Zero;
         private IntPtr aggroAddress = IntPtr.Zero;
+        private IntPtr inCombatAddress = IntPtr.Zero;
 
         private const string charmapSignature = "48c1ea0381faa7010000????8bc2488d0d";
         private const string targetSignatureH0 = "83E901740832C04883C4205BC3488D0D"; // pre hotfix
         private const string targetSignatureH1 = "e8f2652f0084c00f8591010000488d0d"; // post hotfix 1
         private const string enmitySignature = "83f9ff7412448b048e8bd3488d0d";
+        private const string inCombatSignature = "84c07425450fb6c7488d0d";
 
         // Offsets from the signature to find the correct address.
         private const int charmapSignatureOffset = 0;
         private const int targetSignatureOffset = 0;
         private const int enmitySignatureOffset = -2608;
         private const int aggroEnmityOffset = -2336;
+        private const int inCombatSignatureBaseOffset = 0;
+        private const int inCombatSignatureOffsetOffset = 5;
 
         // Offsets from the targetAddress to find the correct target type.
         private const int targetTargetOffset = 176;
@@ -51,6 +55,7 @@ namespace RainbowMage.OverlayPlugin.EventSources
             targetAddress = IntPtr.Zero;
             enmityAddress = IntPtr.Zero;
             aggroAddress = IntPtr.Zero;
+            inCombatAddress = IntPtr.Zero;
         }
 
         private bool HasValidPointers()
@@ -62,6 +67,8 @@ namespace RainbowMage.OverlayPlugin.EventSources
             if (enmityAddress == IntPtr.Zero)
                 return false;
             if (aggroAddress == IntPtr.Zero)
+                return false;
+            if (inCombatAddress == IntPtr.Zero)
                 return false;
             return true;
         }
@@ -140,10 +147,30 @@ namespace RainbowMage.OverlayPlugin.EventSources
                 success = false;
             }
 
+            /// IN COMBAT
+            // The in combat address is set from a combination of two values, a base address and an offset.
+            // They are found adjacent to the same signature, but at different offsets.
+            var baseList = memory.SigScan(inCombatSignature, inCombatSignatureBaseOffset, bRIP);
+            // SigScan returns pointers, but the offset is a 32-bit immediate value.  Do not use RIP.
+            var offsetList = memory.SigScan(inCombatSignature, inCombatSignatureOffsetOffset, false);
+            if (baseList != null && baseList.Count > 0 && offsetList != null && offsetList.Count > 0)
+            {
+                var baseAddress = baseList[0];
+                var offset = (int)(((UInt64)offsetList[0]) & 0xFFFFFFFF);
+                inCombatAddress = IntPtr.Add(baseAddress, offset);
+            }
+            else
+            {
+                inCombatAddress = IntPtr.Zero;
+                fail.Add(nameof(inCombatAddress));
+                success = false;
+            }
+
             logger.Log(LogLevel.Debug, "charmapAddress: 0x{0:X}", charmapAddress.ToInt64());
             logger.Log(LogLevel.Debug, "enmityAddress: 0x{0:X}", enmityAddress.ToInt64());
             logger.Log(LogLevel.Debug, "aggroAddress: 0x{0:X}", aggroAddress.ToInt64());
             logger.Log(LogLevel.Debug, "targetAddress: 0x{0:X}", targetAddress.ToInt64());
+            logger.Log(LogLevel.Debug, "inCombatAddress: 0x{0:X}", inCombatAddress.ToInt64());
             Combatant c = GetSelfCombatant();
             if (c != null)
             {
@@ -590,6 +617,14 @@ namespace RainbowMage.OverlayPlugin.EventSources
 
                 return effectEntry;
             }
+        }
+
+        public override bool GetInCombat()
+        {
+            if (inCombatAddress == IntPtr.Zero)
+                return false;
+            byte[] bytes = memory.Read8(inCombatAddress, 1);
+            return bytes[0] != 0;
         }
     }
 }

--- a/OverlayPlugin.Core/EventSources/EnmityMemoryCommon.cs
+++ b/OverlayPlugin.Core/EventSources/EnmityMemoryCommon.cs
@@ -102,5 +102,6 @@ namespace RainbowMage.OverlayPlugin.EventSources
         abstract public List<Combatant> GetCombatantList();
         abstract public List<EnmityEntry> GetEnmityEntryList(List<Combatant> combatantList);
         abstract public unsafe List<AggroEntry> GetAggroList(List<Combatant> combatantList);
+        abstract public bool GetInCombat();
     }
 }

--- a/OverlayPlugin.Core/EventSources/MiniParseEventSource.cs
+++ b/OverlayPlugin.Core/EventSources/MiniParseEventSource.cs
@@ -317,6 +317,19 @@ namespace RainbowMage.OverlayPlugin.EventSources
                         charName,
                     }));
                     break;
+
+                case LogMessageType.Network6D:
+                    if (!Config.EndEncounterAfterWipe) break;
+                    if (line.Length < 4) break;
+
+                    if (line[3] == "40000010")
+                    {
+                        ActGlobals.oFormActMain.Invoke((Action)(() =>
+                        {
+                           ActGlobals.oFormActMain.EndCombat(true);
+                        }));
+                    }
+                    break;
             }
 
             DispatchEvent(JObject.FromObject(new


### PR DESCRIPTION
This adds common OverlayPlugin logic for the Network6D wipe lines, that is already implemented in both cactbot and Triggernometry.

This also reimplements the work from @KattTails in this [cactbot branch](https://github.com/KattTails/cactbot/tree/act-encounters) to end encounters after a set amount of time.