### PR TITLE
Add workaround for PartyChangedEvent during d/c

### DIFF
--- a/OverlayPlugin.Core/EventSources/MiniParseEventSource.cs
+++ b/OverlayPlugin.Core/EventSources/MiniParseEventSource.cs
@@ -20,6 +20,7 @@ namespace RainbowMage.OverlayPlugin.EventSources
         private bool prevEncounterActive { get; set; }
 
         private List<string> importedLogs = new List<string>();
+        private Dictionary<uint, PartyMember> cachedPartyMembers = new Dictionary<uint, PartyMember>();
         private static Dictionary<uint, string> StatusMap = new Dictionary<uint, string>
         {
             { 0, "Online" },
@@ -188,7 +189,7 @@ namespace RainbowMage.OverlayPlugin.EventSources
                 DispatchAndCacheEvent(obj);
             };
 
-            FFXIVRepository.RegisterPartyChangeDelegate((partyList, partySize) => DispatchPartyChangeEvent());
+            FFXIVRepository.RegisterPartyChangeDelegate((partyList, partySize) => DispatchPartyChangeEvent(partyList, partySize));
         }
 
         private List<Dictionary<string, object>> GetCombatants(List<uint> ids, List<string> names, List<string> props)
@@ -339,27 +340,73 @@ namespace RainbowMage.OverlayPlugin.EventSources
             public bool inParty;
         }
 
-        private void DispatchPartyChangeEvent()
+        private void DispatchPartyChangeEvent(ReadOnlyCollection<uint> partyList, int partySize)
         {
+            // To prevent the cached party member list from growing
+            // indefinitely, reset whenever you are no longer in a party.
+            if (partySize == 0)
+                this.cachedPartyMembers.Clear();
+
             var combatants = FFXIVRepository.GetCombatants();
             if (combatants == null)
                 return;
 
-            List<PartyMember> result = new List<PartyMember>(24);
+            // This is a bit of a hack.  The goal is to return a set of party
+            // and alliance players, along with their jobs, ids, and names.
+            //
+            // |partySize| is only the size of your party, but the list of ids
+            // contains ids from both party and alliance members.
+            //
+            // Additionally, there is a race where |combatants| is not updated
+            // by the time this function is called.  However, this only seems
+            // to happen in the case of disconnects and never when zoning in.
+            // As a workaround, cache the last state of each party member, so
+            // that we can always send info for everybody in your immediate
+            // party.
+            //
+            // Alternatives:
+            // * poll GetCombatants until all party members exist (infinitely?)
+            // * find better memory location of party list
+            // * make this function only return the values from the delegate
+            // * make callers handle this via calling GetCombatants explicitly
 
-            // The partyList contents from the PartyListChangedDelegate
-            // are equivalent to the set of ids enumerated by |query|
+            // Update cached member info.
             var query = combatants.Where(c => c.PartyType != PartyTypeEnum.None);
             foreach (var c in query)
             {
-                result.Add(new PartyMember()
+                var member = new PartyMember()
                 {
                     id = $"{c.ID:X}",
                     name = c.Name,
                     worldId = c.WorldID,
                     job = c.Job,
                     inParty = c.PartyType == PartyTypeEnum.Party,
-                });
+                };
+
+                this.cachedPartyMembers[c.ID] = member;
+            }
+
+            // Accumulate party members from cached info.  If they don't exist,
+            // still send *something*, since it's better than nothing.
+            List<PartyMember> result = new List<PartyMember>(24);
+            foreach (var id in partyList)
+            {
+                PartyMember member;
+                if (this.cachedPartyMembers.TryGetValue(id, out member))
+                {
+                    result.Add(member);
+                }
+                else
+                {
+                    result.Add(new PartyMember()
+                    {
+                        id = $"{id:X}",
+                        name = "",
+                        worldId = 0,
+                        job = 0,
+                        inParty = true,
+                    });
+                }
             }
 
             DispatchAndCacheEvent(JObject.FromObject(new


### PR DESCRIPTION
When a player disconnects and reconnects, the combatant list is not up
to date when the PlayerListChangedDelegate is called.  As this only
seems to happen during these scenarios, caching the last sent player
info seems like a sufficient workaround.

Alternatives are left as comments.

Fixes #123.