### PR TITLE
Correct Ember WebSocket host in streamer docs

### DIFF
--- a/docs/streamers.md
+++ b/docs/streamers.md
@@ -23,6 +23,6 @@ If you change the WSServer settings, you'll have to change the `HOST_PORT` param
 * Kagerou: https://idyllshi.re/kagerou/overlay/?HOST_PORT=ws://127.0.0.1:10501/<br>
   The official URL can be used as well but results in a 404 for some people. This URL should work for everyone.
 * MopiMopi: https://haeruhaeru.github.io/mopimopi/?HOST_PORT=ws://127.0.0.1:10501/
-* Ember: https://goldenchrysus.github.io/ffxiv/ember-overlay/?HOST_PORT=ws://10.10.23.51:10501/
+* Ember: https://goldenchrysus.github.io/ffxiv/ember-overlay/?HOST_PORT=ws://127.0.0.1:10501/
 * Horizoverlay: https://bsides.github.io/horizoverlay/?HOST_PORT=ws://127.0.0.1:10501/
 * Ikegami: https://idyllshi.re/ikegami/?HOST_PORT=ws://127.0.0.1:10501/

--- a/docs/streamers_cn.md
+++ b/docs/streamers_cn.md
@@ -23,6 +23,6 @@ layout: article
 * Kagerou: https://idyllshi.re/kagerou/overlay/?HOST_PORT=ws://127.0.0.1:10501/<br>
   也可以使用官方URL，但对于某些人来说会显示404。此URL应适用于所有人。
 * MopiMopi: https://haeruhaeru.github.io/mopimopi/?HOST_PORT=ws://127.0.0.1:10501/
-* Ember: https://goldenchrysus.github.io/ffxiv/ember-overlay/?HOST_PORT=ws://10.10.23.51:10501/
+* Ember: https://goldenchrysus.github.io/ffxiv/ember-overlay/?HOST_PORT=ws://127.0.0.1:10501/
 * Horizoverlay: https://bsides.github.io/horizoverlay/?HOST_PORT=ws://127.0.0.1:10501/
 * Ikegami: https://idyllshi.re/ikegami/?HOST_PORT=ws://127.0.0.1:10501/


### PR DESCRIPTION
**Issue**

The WebSocket example host listed for Ember in the streamer docs is inconsistent with the host listed for other overlays and is not the host used by default in OverlayPlugin. This may cause users to use the incorrect URL in OBS and lead them to believe Ember does not work for them or that there is a misconfiguration with their ACT.

**Resolution**

This branch changes the incorrect `10.10.23.51` host to the standard `127.0.0.1` host in both the English and Chinese streamer docs for Ember.