### PR TITLE
Start targetbars hidden to avoid a flash when starting

### DIFF
--- a/OverlayPlugin.Core/resources/targetbars/focus_target.html
+++ b/OverlayPlugin.Core/resources/targetbars/focus_target.html
@@ -9,7 +9,7 @@
   <script src="targetbars.js"></script>
 </head>
 <body class="resize-background">
-  <div id="container-focus" class="bar"></div>
+  <div id="container-focus" class="bar hidden"></div>
   <div id="settings-container">
     <div id="settings"></div>
   </div>

--- a/OverlayPlugin.Core/resources/targetbars/hover_target.html
+++ b/OverlayPlugin.Core/resources/targetbars/hover_target.html
@@ -9,7 +9,7 @@
   <script src="targetbars.js"></script>
 </head>
 <body class="resize-background">
-  <div id="container-hover" class="bar"></div>
+  <div id="container-hover" class="bar hidden"></div>
   <div id="settings-container">
     <div id="settings"></div>
   </div>

--- a/OverlayPlugin.Core/resources/targetbars/target.html
+++ b/OverlayPlugin.Core/resources/targetbars/target.html
@@ -9,7 +9,7 @@
   <script src="targetbars.js"></script>
 </head>
 <body class="resize-background">
-  <div id="container-target" class="bar"></div>
+  <div id="container-target" class="bar hidden"></div>
   <div id="settings-container">
     <div id="settings"></div>
   </div>

--- a/OverlayPlugin.Core/resources/targetbars/target_of_target.html
+++ b/OverlayPlugin.Core/resources/targetbars/target_of_target.html
@@ -9,7 +9,7 @@
   <script src="targetbars.js"></script>
 </head>
 <body class="resize-background">
-  <div id="container-targetoftarget" class="bar"></div>
+  <div id="container-targetoftarget" class="bar hidden"></div>
   <div id="settings-container">
     <div id="settings"></div>
   </div>

--- a/OverlayPlugin.Core/resources/targetbars/targetbars.css
+++ b/OverlayPlugin.Core/resources/targetbars/targetbars.css
@@ -7,7 +7,7 @@ html {
 }
 
 .hidden {
-  display: none !important;
+  visibility: hidden !important;
 }
 
 .rounded {


### PR DESCRIPTION
Also, switch from display:none to visibility:hidden to avoid layout problems
in the targetbars.js:447 "alignment hack" when elements are not taking
up space in the layout.