### PR TITLE
Add Kagami Preset

### DIFF
--- a/OverlayPlugin.Core/resources/presets.json
+++ b/OverlayPlugin.Core/resources/presets.json
@@ -53,6 +53,12 @@
     "size": [800, 300],
     "supports": ["actws"]
   },
+  "Kagami": {
+    "type": "MiniParse",
+    "url": "https://ramram1048.github.io/kagami/",
+    "size": [800, 400],
+    "supports": ["modern"]
+  },
   "Basic RainbowMage": {
     "type": "MiniParse",
     "url": "%%/miniparse.html",


### PR DESCRIPTION
Kagami is a skill-display overlay similar to Skill Overlay, but with more features such as positionals/auto-attack/pet tracking and more config options such as speed and icon scale.