### PR TITLE
Update getCombatants to be Case Insensitive

### DIFF
--- a/OverlayPlugin.Core/EventSources/MiniParseEventSource.cs
+++ b/OverlayPlugin.Core/EventSources/MiniParseEventSource.cs
@@ -279,7 +279,7 @@ namespace RainbowMage.OverlayPlugin.EventSources
                     {
                         foreach (var name in names)
                         {
-                            if (combatantName.Equals(name, StringComparison.InvariantCultureIgnoreCase))
+                            if (String.equals(combatantName, name, StringComparison.InvariantCultureIgnoreCase))
                             {
                                 include = true;
                                 break;

--- a/OverlayPlugin.Core/EventSources/MiniParseEventSource.cs
+++ b/OverlayPlugin.Core/EventSources/MiniParseEventSource.cs
@@ -258,7 +258,7 @@ namespace RainbowMage.OverlayPlugin.EventSources
 
                 bool include = false;
 
-                var combatantName = CachedCombatantPropertyInfos["Name"].GetValue(combatant);
+                var combatantName = CachedCombatantPropertyInfos["Name"].GetValue(combatant).ToString();
 
                 if (ids.Count == 0 && names.Count == 0)
                 {

--- a/OverlayPlugin.Core/EventSources/MiniParseEventSource.cs
+++ b/OverlayPlugin.Core/EventSources/MiniParseEventSource.cs
@@ -279,7 +279,7 @@ namespace RainbowMage.OverlayPlugin.EventSources
                     {
                         foreach (var name in names)
                         {
-                            if (combatantName.Equals(name))
+                            if (combatantName.Equals(name, StringComparison.CurrentCultureIgnoreCase))
                             {
                                 include = true;
                                 break;

--- a/OverlayPlugin.Core/EventSources/MiniParseEventSource.cs
+++ b/OverlayPlugin.Core/EventSources/MiniParseEventSource.cs
@@ -279,7 +279,7 @@ namespace RainbowMage.OverlayPlugin.EventSources
                     {
                         foreach (var name in names)
                         {
-                            if (String.equals(combatantName, name, StringComparison.InvariantCultureIgnoreCase))
+                            if (String.Equals(combatantName, name, StringComparison.InvariantCultureIgnoreCase))
                             {
                                 include = true;
                                 break;

--- a/OverlayPlugin.Core/EventSources/MiniParseEventSource.cs
+++ b/OverlayPlugin.Core/EventSources/MiniParseEventSource.cs
@@ -279,7 +279,7 @@ namespace RainbowMage.OverlayPlugin.EventSources
                     {
                         foreach (var name in names)
                         {
-                            if (combatantName.Equals(name, StringComparison.CurrentCultureIgnoreCase))
+                            if (combatantName.Equals(name, StringComparison.InvariantCultureIgnoreCase))
                             {
                                 include = true;
                                 break;


### PR DESCRIPTION
Huge apologies in advance if something is wrong here, I'm just making this change via the GitHub UI instead of properly cloning it down. This is essentially coming from https://github.com/quisquous/cactbot/pull/2171#discussion_r548222080, which seems like the XIVAPI client is saying that the French name for the combatant would be lowercase. It might make sense to just have a case insensitive check here.