### PR TITLE
Fix build error due to missing reference

### DIFF
--- a/OverlayPlugin.Core/OverlayPlugin.Core.csproj
+++ b/OverlayPlugin.Core/OverlayPlugin.Core.csproj
@@ -51,6 +51,7 @@
     <Reference Include="System.Core" />
     <Reference Include="System.Drawing" />
     <Reference Include="System.Runtime.Serialization" />
+    <Reference Include="System.Web" />
     <Reference Include="System.Windows.Forms" />
     <Reference Include="System.Xml.Linq" />
     <Reference Include="System.Data.DataSetExtensions" />


### PR DESCRIPTION
This wouldn't build for me following the instructions in the readme until I added this reference so it's likely someone else may run into this issue.

You might want to bump the version too so it matches the current release for interoperability reasons, just a heads up.