### PR TITLE
added Buffs to GetCombatants

### DIFF
--- a/OverlayPlugin.Core/EventSources/MiniParseEventSource.cs
+++ b/OverlayPlugin.Core/EventSources/MiniParseEventSource.cs
@@ -58,7 +58,8 @@ namespace RainbowMage.OverlayPlugin.EventSources
             "PosX",
             "PosY",
             "PosZ",
-            "Heading"
+            "Heading",
+            "Effects"
         };
 
         private Dictionary<string, System.Reflection.PropertyInfo> CachedCombatantPropertyInfos


### PR DESCRIPTION
chat result with valarin about missing information compared to EnmityAggroList, should allow to get the same information when combining PartyChanged event and GetCombatants as EnmityAggroList. 

A EnmityPartyList would still be better.