### PR TITLE
Improve EffectiveDistance precision in target bars

### DIFF
--- a/OverlayPlugin.Core/EventSources/EnmityEventSource.cs
+++ b/OverlayPlugin.Core/EventSources/EnmityEventSource.cs
@@ -266,6 +266,7 @@ namespace RainbowMage.OverlayPlugin.EventSources
                         enmity.TargetOfTarget = combatants.FirstOrDefault((Combatant x) => x.ID == (enmity.Target.TargetID));
                     }
                     enmity.Target.Distance = mychar.DistanceString(enmity.Target);
+                    enmity.Target.EffectiveDistance = mychar.EffectiveDistanceString(enmity.Target);
 
                     if (enmity.Target.Type == ObjectType.Monster)
                     {
@@ -281,14 +282,17 @@ namespace RainbowMage.OverlayPlugin.EventSources
                     if (enmity.Focus != null)
                     {
                         enmity.Focus.Distance = mychar.DistanceString(enmity.Focus);
+                        enmity.Focus.EffectiveDistance = mychar.EffectiveDistanceString(enmity.Focus);
                     }
                     if (enmity.Hover != null)
                     {
                         enmity.Hover.Distance = mychar.DistanceString(enmity.Hover);
+                        enmity.Hover.EffectiveDistance = mychar.EffectiveDistanceString(enmity.Hover);
                     }
                     if (enmity.TargetOfTarget != null)
                     {
                         enmity.TargetOfTarget.Distance = mychar.DistanceString(enmity.TargetOfTarget);
+                        enmity.TargetOfTarget.EffectiveDistance = mychar.EffectiveDistanceString(enmity.TargetOfTarget);
                     }
                 }
             }

--- a/OverlayPlugin.Core/MemoryProcessors/EnmityMemory50.cs
+++ b/OverlayPlugin.Core/MemoryProcessors/EnmityMemory50.cs
@@ -387,7 +387,7 @@ namespace RainbowMage.OverlayPlugin.MemoryProcessors
                     ID = mem.ID,
                     OwnerID = mem.OwnerID == emptyID ? 0 : mem.OwnerID,
                     Type = (ObjectType)mem.Type,
-                    EffectiveDistance = mem.EffectiveDistance,
+                    RawEffectiveDistance = mem.EffectiveDistance,
                     PosX = mem.PosX,
                     PosY = mem.PosY,
                     PosZ = mem.PosZ,

--- a/OverlayPlugin.Core/MemoryProcessors/EnmityMemory52.cs
+++ b/OverlayPlugin.Core/MemoryProcessors/EnmityMemory52.cs
@@ -403,7 +403,7 @@ namespace RainbowMage.OverlayPlugin.MemoryProcessors
                     ID = mem.ID,
                     OwnerID = mem.OwnerID == emptyID ? 0 : mem.OwnerID,
                     Type = (ObjectType)mem.Type,
-                    EffectiveDistance = mem.EffectiveDistance,
+                    RawEffectiveDistance = mem.EffectiveDistance,
                     PosX = mem.PosX,
                     PosY = mem.PosY,
                     PosZ = mem.PosZ,

--- a/OverlayPlugin.Core/MemoryProcessors/EnmityMemory53.cs
+++ b/OverlayPlugin.Core/MemoryProcessors/EnmityMemory53.cs
@@ -405,7 +405,7 @@ namespace RainbowMage.OverlayPlugin.MemoryProcessors
                     ID = mem.ID,
                     OwnerID = mem.OwnerID == emptyID ? 0 : mem.OwnerID,
                     Type = (ObjectType)mem.Type,
-                    EffectiveDistance = mem.EffectiveDistance,
+                    RawEffectiveDistance = mem.EffectiveDistance,
                     PosX = mem.PosX,
                     PosY = mem.PosY,
                     PosZ = mem.PosZ,

--- a/OverlayPlugin.Core/MemoryProcessors/EnmityMemory54.cs
+++ b/OverlayPlugin.Core/MemoryProcessors/EnmityMemory54.cs
@@ -402,7 +402,7 @@ namespace RainbowMage.OverlayPlugin.MemoryProcessors
                     ID = mem.ID,
                     OwnerID = mem.OwnerID == emptyID ? 0 : mem.OwnerID,
                     Type = (ObjectType)mem.Type,
-                    EffectiveDistance = mem.EffectiveDistance,
+                    RawEffectiveDistance = mem.EffectiveDistance,
                     PosX = mem.PosX,
                     PosY = mem.PosY,
                     PosZ = mem.PosZ,

--- a/OverlayPlugin.Core/MemoryProcessors/EnmityMemory55.cs
+++ b/OverlayPlugin.Core/MemoryProcessors/EnmityMemory55.cs
@@ -419,7 +419,7 @@ namespace RainbowMage.OverlayPlugin.MemoryProcessors
                     ModelStatus = (ModelStatus)mem.ModelStatus,
                     // Normalize all possible aggression statuses into the basic 4 ones.
                     AggressionStatus = (AggressionStatus)(mem.AggressionStatus - (mem.AggressionStatus / 4) * 4),
-                    EffectiveDistance = mem.EffectiveDistance,
+                    RawEffectiveDistance = mem.EffectiveDistance,
                     PosX = mem.PosX,
                     PosY = mem.PosY,
                     PosZ = mem.PosZ,
@@ -649,7 +649,7 @@ namespace RainbowMage.OverlayPlugin.MemoryProcessors
                     CurrentHP = combatant.CurrentHP,
                     MaxHP = combatant.CurrentHP,
                     IsEngaged = (combatant.AggressionStatus >= AggressionStatus.EngagedPassive),
-                    EffectiveDistance = combatant.EffectiveDistance
+                    EffectiveDistance = combatant.RawEffectiveDistance
                 };
                 enemyList.Add(entry);
             }

--- a/OverlayPlugin.Core/MemoryProcessors/EnmityMemory60.cs
+++ b/OverlayPlugin.Core/MemoryProcessors/EnmityMemory60.cs
@@ -360,6 +360,9 @@ namespace RainbowMage.OverlayPlugin.MemoryProcessors
             [FieldOffset(0xB0)]
             public Single Rotation;
 
+            [FieldOffset(0XC0)]
+            public Single Radius;
+
             [FieldOffset(0x1940)]
             public uint TargetID;
 
@@ -419,11 +422,12 @@ namespace RainbowMage.OverlayPlugin.MemoryProcessors
                     ModelStatus = (ModelStatus)mem.ModelStatus,
                     // Normalize all possible aggression statuses into the basic 4 ones.
                     AggressionStatus = (AggressionStatus)(mem.AggressionStatus - (mem.AggressionStatus / 4) * 4),
-                    EffectiveDistance = mem.EffectiveDistance,
+                    RawEffectiveDistance = mem.EffectiveDistance,
                     PosX = mem.PosX,
                     PosY = mem.PosY,
                     PosZ = mem.PosZ,
                     Rotation = mem.Rotation,
+                    Radius = mem.Radius,
                     TargetID = mem.TargetID,
                     CurrentHP = mem.CurrentHP,
                     MaxHP = mem.MaxHP,
@@ -649,7 +653,7 @@ namespace RainbowMage.OverlayPlugin.MemoryProcessors
                     CurrentHP = combatant.CurrentHP,
                     MaxHP = combatant.CurrentHP,
                     IsEngaged = (combatant.AggressionStatus >= AggressionStatus.EngagedPassive),
-                    EffectiveDistance = combatant.EffectiveDistance
+                    EffectiveDistance = combatant.RawEffectiveDistance
                 };
                 enemyList.Add(entry);
             }

--- a/OverlayPlugin.Core/MemoryProcessors/EnmityMemoryCommon.cs
+++ b/OverlayPlugin.Core/MemoryProcessors/EnmityMemoryCommon.cs
@@ -118,19 +118,34 @@ namespace RainbowMage.OverlayPlugin.MemoryProcessors
         public Single PosY;
         public Single PosZ;
         public Single Rotation;
+        public Single Radius;
 
         public string Distance;
-        public byte EffectiveDistance;
+        public string EffectiveDistance;
+        [NonSerialized]
+        public byte RawEffectiveDistance;
 
         public List<EffectEntry> Effects;
 
-        public string DistanceString(Combatant target)
+        private Single GetDistance(Combatant target)
         {
             var distanceX = (float)Math.Abs(PosX - target.PosX);
             var distanceY = (float)Math.Abs(PosY - target.PosY);
             var distanceZ = (float)Math.Abs(PosZ - target.PosZ);
-            var distance = (float)Math.Sqrt((distanceX * distanceX) + (distanceY * distanceY) + (distanceZ * distanceZ));
-            return distance.ToString("0.00");
+            return (Single)Math.Sqrt((distanceX * distanceX) + (distanceY * distanceY) + (distanceZ * distanceZ));
+        }
+
+        public string DistanceString(Combatant target)
+        {
+            return GetDistance(target).ToString("0.00");
+        }
+
+        public string EffectiveDistanceString(Combatant target)
+        {
+            // Mild hack for backwards compat for pre-6.x with no Radius memory location.
+            if (target.Radius == 0)
+                return this.RawEffectiveDistance.ToString("0.00");
+            return (GetDistance(target) - target.Radius).ToString("0.00");
         }
     }
 

--- a/OverlayPlugin.Core/resources/targetbars/targetbars.js
+++ b/OverlayPlugin.Core/resources/targetbars/targetbars.js
@@ -152,7 +152,7 @@ const formatOptionsByKey = {
     minimumFractionDigits: 2,
   },
   EffectiveDistance: {
-    maximumFractionDigits: 0,
+    minimumFractionDigits: 2,
   },
   PercentHP: {
     minimumFractionDigits: 2,

--- a/OverlayPlugin.Core/resources/targetbars/targetbars.js
+++ b/OverlayPlugin.Core/resources/targetbars/targetbars.js
@@ -444,7 +444,10 @@ function defaultAsPx(str) {
 // e.g. num=123456789, digits=3 => 123M
 // e.g. num=123456789, digits=4 => 123.4M
 // e.g. num=-0.1234567, digits=3 => -0.123
-function formatNumberSimplify(num, lang, options, digits) {
+function formatNumberSimplify(signedNum, lang, options, digits) {
+  const sign = signedNum < 0 ? -1 : 1;
+  let num = Math.abs(signedNum);
+
   // The leading zero does not count.
   if (num < 1)
     digits++;
@@ -481,7 +484,7 @@ function formatNumberSimplify(num, lang, options, digits) {
   num = Math.floor(num * shift) / shift;
 
   const locale = languageToLocale[lang] || languageToLocale[defaultLang];
-  return num.toLocaleString(locale, {
+  return (sign * num).toLocaleString(locale, {
     minimumFractionDigits: decimalPlacesNeeded,
     maximumFractionDigits: decimalPlacesNeeded,
   }) + suffix;


### PR DESCRIPTION
EffectiveDistance is just a (rounded) byte and so is not that useful
for determining exact distances from boss mechanics.  This PR
changes EffectiveDistance to be a float based on the Radius when
on 6.x.  For backwards compatibility, pre-6.x users will get the
rounded byte.

Belated thanks to @KattTails for the memory location for radius!