### PR TITLE
Fix in combat signature

### DIFF
--- a/OverlayPlugin.Core/MemoryProcessors/EnmityMemory61.cs
+++ b/OverlayPlugin.Core/MemoryProcessors/EnmityMemory61.cs
@@ -25,7 +25,7 @@ namespace RainbowMage.OverlayPlugin.MemoryProcessors
         private const string charmapSignature = "48c1ea0381faa9010000????8bc2488d0d";
         private const string targetSignature = "83E901740832C04883C4205BC3488D0D";
         private const string enmitySignature = "83f9ff7412448b048e8bd3488d0d";
-        private const string inCombatSignature = "4889742420574883ec200fb60233f68905";
+        private const string inCombatSignature = "803D????????000F95C04883C428";
         private const string enmityHudSignature = "48895C246048897C2470488B3D";
 
         // Offsets from the signature to find the correct address.
@@ -33,7 +33,8 @@ namespace RainbowMage.OverlayPlugin.MemoryProcessors
         private const int targetSignatureOffset = 0;
         private const int enmitySignatureOffset = -2608;
         private const int aggroEnmityOffset = -2336;
-        private const int inCombatSignatureOffset = 0;
+        private const int inCombatSignatureOffset = -12;
+        private const int inCombatRIPOffset = 1;
         private const int enmityHudSignatureOffset = 0;
         private readonly int[] enmityHudPointerPath = new int[] { 0x30, 0x58, 0x98, 0x20 };
 
@@ -155,7 +156,7 @@ namespace RainbowMage.OverlayPlugin.MemoryProcessors
             }
 
             /// IN COMBAT
-            list = memory.SigScan(inCombatSignature, inCombatSignatureOffset, bRIP);
+            list = memory.SigScan(inCombatSignature, inCombatSignatureOffset, bRIP, inCombatRIPOffset);
 
             if (list != null && list.Count > 0)
             {

--- a/OverlayPlugin.Core/MemoryProcessors/FFXIVMemory.cs
+++ b/OverlayPlugin.Core/MemoryProcessors/FFXIVMemory.cs
@@ -288,7 +288,7 @@ namespace RainbowMage.OverlayPlugin.MemoryProcessors
         /// <param name="offset">The offset from the end of the found pattern to read a pointer from the process memory.</param>
         /// <param name="rip_addressing">Uses x64 RIP relative addressing mode</param>
         /// <returns>A list of pointers read relative to the end of strings in the process memory matching the |pattern|.</returns>
-        public List<IntPtr> SigScan(string pattern, int offset, bool rip_addressing)
+        public List<IntPtr> SigScan(string pattern, int pattern_offset, bool rip_addressing, int rip_offset = 0)
         {
             List<IntPtr> matches_list = new List<IntPtr>();
 
@@ -333,7 +333,7 @@ namespace RainbowMage.OverlayPlugin.MemoryProcessors
                 IntPtr num_bytes_read = IntPtr.Zero;
                 if (NativeMethods.ReadProcessMemory(processHandle, read_start_addr, read_buffer, read_size, ref num_bytes_read))
                 {
-                    int max_search_offset = num_bytes_read.ToInt32() - pattern_array.Length - Math.Max(0, offset);
+                    int max_search_offset = num_bytes_read.ToInt32() - pattern_array.Length - Math.Max(0, pattern_offset);
                     // With RIP we will read a 4byte pointer at the |offset|, else we read an 8byte pointer. Either
                     // way we can't find a pattern such that the pointer we want to read is off the end of the buffer.
                     if (rip_addressing)
@@ -360,10 +360,10 @@ namespace RainbowMage.OverlayPlugin.MemoryProcessors
                             IntPtr pointer;
                             if (rip_addressing)
                             {
-                                Int32 rip_ptr_offset = BitConverter.ToInt32(read_buffer, search_offset + pattern_array.Length + offset);
+                                Int32 rip_ptr_offset = BitConverter.ToInt32(read_buffer, search_offset + pattern_array.Length + pattern_offset);
                                 Int64 pattern_start_game_addr = read_start_addr.ToInt64() + search_offset;
-                                Int64 pointer_offset_from_pattern_start = pattern_array.Length + offset;
-                                Int64 rip_ptr_base = pattern_start_game_addr + pointer_offset_from_pattern_start + 4;
+                                Int64 pointer_offset_from_pattern_start = pattern_array.Length + pattern_offset;
+                                Int64 rip_ptr_base = pattern_start_game_addr + pointer_offset_from_pattern_start + 4 + rip_offset;
                                 // In RIP addressing, the pointer from the executable is 32bits which we stored as |rip_ptr_offset|. The pointer
                                 // is then added to the address of the byte following the pointer, making it relative to that address, which we
                                 // stored as |rip_ptr_base|.
@@ -372,7 +372,7 @@ namespace RainbowMage.OverlayPlugin.MemoryProcessors
                             else
                             {
                                 // In normal addressing, the 64bits found with the pattern are the absolute pointer.
-                                pointer = new IntPtr(BitConverter.ToInt64(read_buffer, search_offset + pattern_array.Length + offset));
+                                pointer = new IntPtr(BitConverter.ToInt64(read_buffer, search_offset + pattern_array.Length + pattern_offset));
                             }
                             matches_list.Add(pointer);
                         }


### PR DESCRIPTION
The previous signature gave false "out of combat" signals when dying in combat.

Unfortunately, the line it uses is a `cmp byte` line that doesn't end with the pointer,
so SigScan needs to be updated to be able to handle getting rip addresses from
that style of line.

See corresponding https://github.com/quisquous/cactbot/pull/4268 change.